### PR TITLE
fix: 修复 master 上失败的两条测试

### DIFF
--- a/src/BlueOath.Server/Protocols/ConfigDbLoader.cs
+++ b/src/BlueOath.Server/Protocols/ConfigDbLoader.cs
@@ -18,13 +18,45 @@ internal static class ConfigDbLoader
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// 直接由启动参数传入的客户端路径计算游戏配置目录
+    /// 直接由启动参数传入的客户端路径计算游戏基础配置目录
     /// （<c>{clientPath}/blueoath_Data/StreamingAssets/config</c>），不再向上逐级查找。
+    /// 注意实际生效的配置还要叠加热更目录，见 <see cref="ResolveDbPath"/>。
     /// </summary>
     public static string BuildConfigDir(string clientPath)
     {
         if (string.IsNullOrEmpty(clientPath)) return "";
         return Path.Combine(clientPath, "blueoath_Data", "StreamingAssets", "config");
+    }
+
+    /// <summary>
+    /// 解析某张配置表的实际路径。官方启动器把热更下发的增量配置写到安装根目录的
+    /// <c>config/</c>（与游戏目录平级），客户端运行时按「热更优先、StreamingAssets 兜底」
+    /// 合并——热更目录只包含被改动过的表，其余仍走整包内的基础表。服务端必须遵循同一
+    /// 优先级，否则会和客户端读到不同版本的配置（例如日服停服前最后一次热更新增的
+    /// 舰船与突破链，在基础表里并不存在）。
+    /// </summary>
+    public static string ResolveDbPath(string configDir, string dbFile)
+    {
+        var hotpatch = BuildHotpatchPath(configDir, dbFile);
+        if (hotpatch is not null && File.Exists(hotpatch)) return hotpatch;
+        return Path.Combine(configDir, dbFile);
+    }
+
+    /// <summary>
+    /// 由基础配置目录反推热更配置路径：
+    /// <c>{install}/{client}/blueoath_Data/StreamingAssets/config</c> → <c>{install}/config/{dbFile}</c>。
+    /// 目录层级不符合该形状时返回 <c>null</c>，避免对自定义配置目录做出错误推断。
+    /// </summary>
+    private static string? BuildHotpatchPath(string configDir, string dbFile)
+    {
+        var streamingAssets = Path.GetDirectoryName(configDir);
+        if (streamingAssets is null || !string.Equals(
+                Path.GetFileName(streamingAssets), "StreamingAssets", StringComparison.OrdinalIgnoreCase))
+            return null;
+        var dataDir = Path.GetDirectoryName(streamingAssets);
+        var clientDir = dataDir is null ? null : Path.GetDirectoryName(dataDir);
+        var installDir = clientDir is null ? null : Path.GetDirectoryName(clientDir);
+        return installDir is null ? null : Path.Combine(installDir, "config", dbFile);
     }
 
     /// <summary>
@@ -69,7 +101,7 @@ internal static class ConfigDbLoader
     /// </summary>
     public static void LoadRows(string configDir, string dbFile, Action<int, SqliteDataReader, string> callback)
     {
-        var path = Path.Combine(configDir, dbFile);
+        var path = ResolveDbPath(configDir, dbFile);
         if (!File.Exists(path)) return;
         using var c = new SqliteConnection($"Data Source={path};Mode=ReadOnly");
         c.Open();

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -819,7 +819,10 @@ static Task AccountProfileBootstrapTest()
 
     using JsonDocument plData = JsonDocument.Parse(
         responder.BuildResponse("GET /phone/getPlData/getPlData HTTP/1.1").Body);
-    Assert(plData.RootElement.GetProperty("pid").GetString() == profileId,
+    // 事件 1007 的信封是 errornu/errordesc/data，平台字段（含 pid）都在 data 之下，
+    // 见 BootstrapHttpResponder 的 getPlData 分支；摊到根对象会让 SDK 走 111111
+    // 未知错误分支，因此响应体是对的，断言需跟随该结构。
+    Assert(plData.RootElement.GetProperty("data").GetProperty("pid").GetString() == profileId,
         "getPlData did not expose selected profile");
 
     using JsonDocument login = JsonDocument.Parse(


### PR DESCRIPTION
修复 #61 里的两条测试失败。

改动前 `master` 上是 26 通过 / 2 失败，改动后 **28 全部通过**，0 警告 0 错误。

### 一、`ConfigDbLoader` 逐表叠加热更目录

增加逐表解析，与客户端保持同一优先级：

```csharp
public static string ResolveDbPath(string configDir, string dbFile)
{
    var hotpatch = BuildHotpatchPath(configDir, dbFile);
    if (hotpatch is not null && File.Exists(hotpatch)) return hotpatch;
    return Path.Combine(configDir, dbFile);
}

// {install}/{client}/blueoath_Data/StreamingAssets/config -> {install}/config/{dbFile}
// 目录层级不符合该形状时返回 null，避免对自定义配置目录做出错误推断
private static string? BuildHotpatchPath(string configDir, string dbFile)
{
    var streamingAssets = Path.GetDirectoryName(configDir);
    if (streamingAssets is null || !string.Equals(
            Path.GetFileName(streamingAssets), "StreamingAssets", StringComparison.OrdinalIgnoreCase))
        return null;
    var dataDir = Path.GetDirectoryName(streamingAssets);
    var clientDir = dataDir is null ? null : Path.GetDirectoryName(dataDir);
    var installDir = clientDir is null ? null : Path.GetDirectoryName(clientDir);
    return installDir is null ? null : Path.Combine(installDir, "config", dbFile);
}
```

`LoadRows` 里把 `Path.Combine(configDir, dbFile)` 换成 `ResolveDbPath(configDir, dbFile)`。它是所有 `config_*.db` 的唯一入口（已确认整个服务端没有旁路的 `SqliteConnection`），改这一处即覆盖全部加载器。

未叠加热更配置的安装读到的仍是基础表，行为不变。

### 二、断言改读 `data.pid`

只改断言，响应体不动：

```csharp
Assert(plData.RootElement.GetProperty("data").GetProperty("pid").GetString() == profileId,
    "getPlData did not expose selected profile");
```

同一函数里紧接着的 `hash.RootElement.GetProperty("pid")`（`gethash` 分支）是**对的** —— 那个响应确实把 `pid` 放在根对象，没有一起改。

### 验证

- 服务端启动日志由 `1478 ship infos` 变为 `1490 ship infos`；移走热更层复跑可稳定回退。
- 测试由 26 通过 / 2 失败变为 **28 全部通过**。

两处改动落在不同文件（`ConfigDbLoader.cs` / `Program.cs`），互不影响，需要的话可以拆成两个 PR。

Fixes #61
