### PR TITLE
fix: 抽卡按嵌套结构逐层归一化，恢复配置中的公示出率

### DIFF
--- a/src/BlueOath.Server/Protocols/Services/BuildShipService.cs
+++ b/src/BlueOath.Server/Protocols/Services/BuildShipService.cs
@@ -93,17 +93,15 @@ internal sealed class BuildShipService(GameServices services)
         List<CommonReward> rewards = new();
         services.LastBuildHeroIds.Clear();
 
-        var entries = FlattenDropPool((int)extractConfig.DropItemId);
-        if (entries.Count == 0)
+        int rootDropItemId = (int)extractConfig.DropItemId;
+        if (PoolLevelEntries(rootDropItemId, 1).Count == 0)
             return [];
-
-        // Console.WriteLine(string.Join(",\n", entries));
 
         long extractType = extractConfig.ExtractType;
 
         for (int i = 0; i < num; i++)
         {
-            var entry = WeightedPick(entries);
+            if (DrawFromPool(rootDropItemId) is not { } entry) continue;
             (account, CommonReward reward) = GrantDropReward(account, entry, now);
             rewards.Add(reward);
         }
@@ -114,16 +112,14 @@ internal sealed class BuildShipService(GameServices services)
             bool hasSR = rewards.Any(r => r.Type == GameServices.GoodsTypeShip && GetShipRarity(r.ConfigId) >= GameServices.RaritySR);
             if (!hasSR)
             {
-                var srPlusEntries = entries.Where(
-                    e => e.GoodsType == GameServices.GoodsTypeShip && GetShipRarity(e.ConfigId) >= GameServices.RaritySR).ToList();
-                if (srPlusEntries.Count > 0)
+                if (PoolChance(rootDropItemId, GameServices.RaritySR) > 0)
                 {
                     // 从后往前找到最后一个舰船奖励并替换
                     for (int i = rewards.Count - 1; i >= 0; i--)
                     {
                         if (rewards[i].Type == GameServices.GoodsTypeShip)
                         {
-                            var newEntry = WeightedPick(srPlusEntries);
+                            if (DrawSrPlusFromPool(rootDropItemId) is not { } newEntry) break;
                             uint oldHeroId = (uint)rewards[i].Id;
                             account = GameServices.RemoveHero(account, oldHeroId);
                             services.LastBuildHeroIds.Remove(oldHeroId);
@@ -281,7 +277,150 @@ internal sealed class BuildShipService(GameServices services)
     /// 写入 TCommonReward.Id；否则客户端会把模板当背包道具解析，领奖演出和船坞都会损坏。
     /// 由 <see cref="GrantDropReward"/> 统一处理（本方法已废弃合并）。</summary>
 
-    /// <summary>递归展开 config_drop_item 掉落池，将 GoodsType.DROP 嵌套条目展开为最终物品列表。</summary>
+    /// <summary>掉落池递归深度上限，防止配置里出现自引用子池导致无限下降。</summary>
+    private const int MaxPoolDepth = 8;
+
+    /// <summary>单层掉落池条目 + 该层生效的数量倍率（嵌套条目原样保留，用于递归下降）。</summary>
+    private sealed record PoolLevelEntry(DropPoolEntry Entry, int CountMul);
+
+    /// <summary>
+    /// 取出掉落池「当前这一层」的条目，<b>不</b>展开嵌套：GoodsType.DROP 条目原样保留，
+    /// 其 ConfigId 即子池 id。抽取必须逐层进行，见 <see cref="DrawFromPool"/>。
+    /// </summary>
+    private List<PoolLevelEntry> PoolLevelEntries(int dropItemId, int countMul)
+    {
+        var result = new List<PoolLevelEntry>();
+        if (!services.DropItems.TryGetValue(dropItemId, out var dropItem))
+            return result;
+
+        if (dropItem.DropRate > 0 && dropItem.Drop is { Count: > 0 })
+            AppendLevelEntries(dropItem.Drop, countMul, result);
+
+        if (dropItem.DropAloneCount > 0 && dropItem.DropAlone is { Count: > 0 })
+            AppendLevelEntries(dropItem.DropAlone, (int)dropItem.DropAloneCount * countMul, result);
+
+        return result;
+    }
+
+    private static void AppendLevelEntries(List<List<long>> entries, int countMul, List<PoolLevelEntry> result)
+    {
+        foreach (var entry in entries)
+        {
+            if (entry.Count < 5) continue;
+            int weight = (int)entry[4];
+            if (weight == 0) continue;
+            result.Add(new PoolLevelEntry(
+                new DropPoolEntry((int)entry[0], (int)entry[1],
+                    (int)entry[2] * countMul, (int)entry[3] * countMul, weight),
+                countMul));
+        }
+    }
+
+    /// <summary>
+    /// 按嵌套结构逐层抽取：在当前层按该层自身的权重选出一条，命中 GoodsType.DROP 就进入
+    /// 对应子池再选一次，直到落在实际物品上。
+    ///
+    /// 卡池顶层条目全部是子池入口，其权重即官方公示概率（例如 106 号池
+    /// SSR 150+50、SR 1500、R 8300，合计 10000），因此<b>必须逐层归一化</b>。
+    /// 若把各子池的条目按原始权重平铺进同一张表再抽，父级权重会被整个丢弃，出率退化成
+    /// 「该稀有度有多少条船」——实测会把 SSR 由 2% 抬到 50%~70%，同时让 R 由 83% 掉到 5%~9%。
+    /// </summary>
+    private DropPoolEntry? DrawFromPool(int dropItemId, int countMul = 1)
+    {
+        for (int depth = 0; depth < MaxPoolDepth; depth++)
+        {
+            List<PoolLevelEntry> level = PoolLevelEntries(dropItemId, countMul);
+            if (level.Count == 0) return null;
+
+            PoolLevelEntry picked = PickLevel(level);
+            if (picked.Entry.GoodsType != GameServices.GoodsTypeDrop)
+                return picked.Entry;
+
+            dropItemId = picked.Entry.ConfigId;
+            countMul = picked.CountMul;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 某个掉落池最终产出「品质 &gt;= <paramref name="minRarity"/> 的舰娘」的概率，
+    /// 逐层归一化，与 <see cref="DrawFromPool"/> 的实际抽取口径完全一致。
+    /// 结果应当等于卡池顶层条目的权重占比，即官方公示概率。
+    /// </summary>
+    internal double PoolChance(int dropItemId, int minRarity, int depth = 0)
+    {
+        if (depth >= MaxPoolDepth) return 0;
+        List<PoolLevelEntry> level = PoolLevelEntries(dropItemId, 1);
+        long total = level.Sum(e => (long)e.Entry.Weight);
+        if (total <= 0) return 0;
+
+        double chance = 0;
+        foreach (PoolLevelEntry e in level)
+            chance += (double)e.Entry.Weight / total * BranchChance(e.Entry, minRarity, depth);
+        return chance;
+    }
+
+    private double BranchChance(DropPoolEntry entry, int minRarity, int depth) =>
+        entry.GoodsType == GameServices.GoodsTypeDrop
+            ? PoolChance(entry.ConfigId, minRarity, depth + 1)
+            : entry.GoodsType == GameServices.GoodsTypeShip &&
+              GetShipRarity(entry.ConfigId) >= minRarity ? 1 : 0;
+
+    /// <summary>
+    /// 在「结果为 SR 及以上舰娘」的条件下抽取，用于 10 连保底补发。
+    /// 每个分支按「该分支被选中的权重 × 该分支产出 SR+ 的概率」加权，因此得到的是真实条件
+    /// 分布——按官方 2% SSR / 15% SR 的比例，保底给出 SSR 的概率约为 2/(2+15)。
+    /// </summary>
+    private DropPoolEntry? DrawSrPlusFromPool(int dropItemId, int countMul = 1, int depth = 0)
+    {
+        if (depth >= MaxPoolDepth) return null;
+        List<PoolLevelEntry> level = PoolLevelEntries(dropItemId, countMul);
+        if (level.Count == 0) return null;
+
+        var weighted = level
+            .Select(e => (Level: e, Weight: e.Entry.Weight * BranchChance(e.Entry, GameServices.RaritySR, depth)))
+            .Where(x => x.Weight > 0)
+            .ToList();
+        double total = weighted.Sum(x => x.Weight);
+        if (total <= 0) return null;
+
+        double roll = services.Rng.NextDouble() * total;
+        double cumulative = 0;
+        foreach (var (levelEntry, weight) in weighted)
+        {
+            cumulative += weight;
+            if (roll >= cumulative) continue;
+            return levelEntry.Entry.GoodsType == GameServices.GoodsTypeDrop
+                ? DrawSrPlusFromPool(levelEntry.Entry.ConfigId, levelEntry.CountMul, depth + 1)
+                : levelEntry.Entry;
+        }
+        PoolLevelEntry last = weighted[^1].Level;
+        return last.Entry.GoodsType == GameServices.GoodsTypeDrop
+            ? DrawSrPlusFromPool(last.Entry.ConfigId, last.CountMul, depth + 1)
+            : last.Entry;
+    }
+
+    /// <summary>在单层条目中按权重抽取一条。</summary>
+    private PoolLevelEntry PickLevel(List<PoolLevelEntry> entries)
+    {
+        long totalWeight = entries.Sum(e => (long)e.Entry.Weight);
+        if (totalWeight <= 0) return entries[0];
+        long roll = services.Rng.NextInt64(totalWeight);
+        long cumulative = 0;
+        foreach (PoolLevelEntry e in entries)
+        {
+            cumulative += e.Entry.Weight;
+            if (roll < cumulative)
+                return e;
+        }
+        return entries[^1];
+    }
+
+    /// <summary>
+    /// 递归展开 config_drop_item 掉落池，将 GoodsType.DROP 嵌套条目展开为最终物品列表。
+    /// <b>仅用于枚举池内容</b>（如累计抽数奖励箱一次性发放全部物品）；展开会丢失父级权重，
+    /// 不可用于加权抽取——抽取请用 <see cref="DrawFromPool"/>。
+    /// </summary>
     private List<DropPoolEntry> FlattenDropPool(int dropItemId, int countMul = 1)
     {
         var result = new List<DropPoolEntry>();
@@ -319,22 +458,6 @@ internal sealed class BuildShipService(GameServices services)
                 result.Add(new DropPoolEntry(goodsType, configId, minNum, maxNum, weight));
             }
         }
-    }
-
-    /// <summary>按权重随机抽取一个掉落池条目。</summary>
-    private DropPoolEntry WeightedPick(List<DropPoolEntry> entries)
-    {
-        int totalWeight = entries.Sum(e => e.Weight);
-        if (totalWeight <= 0) return entries[0];
-        int roll = services.Rng.Next(totalWeight);
-        int cumulative = 0;
-        foreach (var e in entries)
-        {
-            cumulative += e.Weight;
-            if (roll < cumulative)
-                return e;
-        }
-        return entries[^1];
     }
 
     /// <summary>通过 ship_info_id 获取舰娘稀有度（quality）。</summary>

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -31,6 +31,7 @@ var tests = new (string Name, Func<Task> Run)[]
     ("building config, lifecycle and assignment codecs match the client", BuildingCodecTest),
     ("story unlock config includes event, side and personal stories", StoryUnlockConfigTest),
     ("illustrate entries unlock every configured behaviour", IllustrateBehaviourUnlockTest),
+    ("gacha pools draw at the rates published in the client config", GachaPoolRateTest),
     ("Mubar battle start preserves CopyType 33", MubarBattleStartCodecTest),
     ("sea-copy entries include non-nil safe-area state", SeaCopySafeAreaCodecTest),
     ("illustrate payload encodes unlocked personal stories", HeroMemoryCodecTest),
@@ -127,6 +128,57 @@ foreach (var (name, run) in tests)
     catch (Exception e) { failed++; Console.Error.WriteLine($"FAIL {name}: {e.Message}"); }
 }
 return failed;
+
+// 卡池顶层条目全是子池入口（GoodsType.DROP），其权重即官方公示概率；子池内部才是具体舰娘，
+// 内部权重只决定「同稀有度里出哪一条」。抽取必须逐层归一化，把子池条目按原始权重平铺到同一张
+// 表再抽会丢掉父级权重，使出率退化成「该稀有度有多少条船」。
+// 以 106 号池为例，顶层是 SSR 150+50 / SR 1500 / R 8300（合计 10000），而各子池的内部权重和分别
+// 是 6 / 57 / 50 / 11 —— 平铺后 SSR 会变成 (6+57)/124 = 50.8%，R 只剩 11/124 = 8.9%。
+static async Task GachaPoolRateTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-gacha-rate-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "gacha-rate";
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        await repo.SaveAccountAsync(PlayerAccountFactory.CreateDefault(profileId, 1));
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+        var buildShip = new BuildShipService(services);
+
+        Assert(services.ExtractShips.TryGetValue(106, out ConfigExtractShip? pool) && pool is not null,
+            "gacha pool 106 is missing from config_extract_ship");
+        int dropItemId = (int)pool!.DropItemId;
+
+        // 官方公示：SSR 2%（UP 1.5% + 常驻 0.5%）、SR 15%、其余 83%。
+        double ssr = buildShip.PoolChance(dropItemId, 4);
+        double srPlus = buildShip.PoolChance(dropItemId, 3);
+        Assert(Math.Abs(ssr - 0.02) < 1e-9,
+            $"pool 106 SSR rate drifted from the published 2%: {ssr:P4}");
+        Assert(Math.Abs(srPlus - 0.17) < 1e-9,
+            $"pool 106 SR-and-above rate drifted from the published 17%: {srPlus:P4}");
+
+        // 其余舰船卡池同样是 2% SSR / 15% SR 的标准结构，一并守住。
+        foreach (int poolId in new[] { 109, 124, 150, 152 })
+        {
+            Assert(services.ExtractShips.TryGetValue(poolId, out ConfigExtractShip? other) && other is not null,
+                $"gacha pool {poolId} is missing from config_extract_ship");
+            double otherSsr = buildShip.PoolChance((int)other!.DropItemId, 4);
+            Assert(Math.Abs(otherSsr - 0.02) < 1e-9,
+                $"pool {poolId} SSR rate drifted from the published 2%: {otherSsr:P4}");
+        }
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
+}
 
 static async Task HeroAdvanceStateTest()
 {


### PR DESCRIPTION
修复 #63。issue 里没展开根因，这里补上，方便对着代码看。
（知道原概率是小巧思但应某位朋友的期待改回了官方概率）

## 根因与证据

`BuildShipService.FlattenDropEntries` 展开嵌套时，把子池条目按**自身原始权重**直接并入同一张表，父级权重读出后从未使用：

```csharp
if (goodsType == GameServices.GoodsTypeDrop)
{
    var nested = FlattenDropPool(configId, countMul);
    result.AddRange(nested);      // weight 已读出，但在这条分支里从未使用
}
```

逐层归一化因此丢失，一个稀有度的出率退化成「该稀有度配了多少条船」—— 选项越丰富反而越容易出。

### 证据：106 号池（`drop_item 2001009`）

| 子池 | 父权重 | 官方概率 | 子池条目数 | 子权重和 | 品质 |
|---|---|---|---|---|---|
| 1001014 | 150 | 1.50% | 4 | 6 | SSR（UP） |
| 1001015 | 50 | 0.50% | 19 | 57 | SSR（常驻） |
| 1001016 | 1500 | 15.00% | 22 | 50 | SR |
| 1000000 | 8300 | **83.00%** | 11 | 11 | R |

平铺后总权重只剩 **124**：

```
SSR = (6+57)/124 = 50.81%     公示 2%
SR  =     50/124 = 40.32%     公示 15%
R   =     11/124 =  8.87%     公示 83%
```

### 七个启用卡池（`build-pools.json`）的偏差

| 池 | SSR 实际 | 应为 | 倍数 | R 实际 | 应为 |
|---|---|---|---|---|---|
| 106 | 50.81% | 2.00% | 25.4x | 8.87% | 83.00% |
| 109 | 65.78% | 2.00% | 32.9x | 5.88% | 83.00% |
| 124 | 70.24% | 2.00% | 35.1x | 5.37% | 83.00% |
| 150 | 54.14% | 2.00% | 27.1x | 8.27% | 83.00% |
| 152 | 69.80% | 2.00% | 34.9x | 5.45% | 83.00% |
| 151 | 0.16% | 1.00% | **0.16x** | — | — |
| 154 | 0.25% | 0.25% | 1.00x | — | — |

151 号池是反向偏低 6 倍。偏差方向不一致，说明调整配置里的权重参数无法修正，必须改实现。

## 改动

不做加权平铺（嵌套一深，权重相乘容易溢出），改成**抽取时递归下降**：在当前层按该层自身权重选一条，命中 `GoodsType.DROP` 就进入子池再选一次，直到落在实际物品上。每层只用整数权重，没有缩放和舍入。

- 新增 `PoolLevelEntries`：只取掉落池当前一层，`GoodsType.DROP` 原样保留，并记录该层生效的数量倍率（`drop_alone_count` 的累乘沿用原语义）。
- 新增 `DrawFromPool`：逐层抽取，深度上限 8 防配置自引用。
- 10 连保底改用 `DrawSrPlusFromPool`：原实现从平铺表里筛 SR+ 再加权选取，递归下降后没有平铺表，改为按「分支被选中的权重 × 该分支产出 SR+ 的概率」逐层加权，得到真实条件分布（按 2%/15% 的比例，保底给出 SSR 的概率约 `2/(2+15)`）。
- 新增 `internal PoolChance(dropItemId, minRarity)` 供测试钉住公示概率。
- 删除已无调用的 `WeightedPick`；`FlattenDropPool` 保留并补注释 —— 它仍被累计抽数奖励箱使用（一次性发放池内**全部**物品、不做加权），但**不可用于加权抽取**，以免以后又被复用回来。

### 验证

- **概率模型**：新增用例断言 106 号池 SSR 精确等于 2.000000000%、SR 及以上 17%（误差 < 1e-9），并对 109/124/150/152 一并断言 SSR = 2%。
- **实际抽取**（概率函数与抽取走的是不同代码路径，单独验）：临时插桩对 106 号池实抽 **400000 次**，SSR **2.0220%**、SR **15.0215%** —— 该样本量下 SSR 的标准差约 0.022%。

本分支基于当前 `master`，跑下来 27 通过 / 2 失败；那 2 条（`selected launcher profile flows through bootstrap login responses` 和 `hero advance preserves neighbors and unbinds consumed equipment`）是 `master` 上原有的失败，与本改动无关，已由 #62 修复。两个 PR 都合入后套件全绿。

Fixes #63
