### PR TITLE
fix: 重复获得舰船不再被判定为首次获得

### DIFF
--- a/src/BlueOath.Server/Protocols/Modules/ShopModule.cs
+++ b/src/BlueOath.Server/Protocols/Modules/ShopModule.cs
@@ -8,7 +8,9 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
 {
     /// <summary>发放结果：更新后的账号 + 生成的奖励（无效商品 Type=0）。</summary>
     private sealed record GoodsGrant(PlayerAccount Account, CommonReward Reward);
-    private sealed record PurchaseResult(byte[] Ret, bool Changed, string Error);
+    /// <summary>本次购买发放的舰娘模板 ID，供推送侧同步图鉴（<see cref="GameServices.BuildBuyPushesAsync"/>）。</summary>
+    private sealed record PurchaseResult(byte[] Ret, bool Changed, string Error,
+        IReadOnlyList<int>? ShipTemplateIds = null);
 
     public IReadOnlyList<string> Prefixes => ["shop", "bag"];
 
@@ -29,7 +31,8 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
                     ErrMsg = purchase.Error,
                     // Lua 购买成功回调会立即读取背包/货币，必须先刷新缓存。
                     PrePushes = purchase.Changed
-                        ? await services.BuildBuyPushesAsync(ctx.ProfileId, (uint)ctx.Now, ctx.Ct)
+                        ? await services.BuildBuyPushesAsync(ctx.ProfileId, (uint)ctx.Now, ctx.Ct,
+                            newShipTemplateIds: purchase.ShipTemplateIds)
                         : [],
                 };
                 break;
@@ -86,7 +89,8 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
         if (grant.Reward.Type == 0) return new([], false, "shop goods could not be granted");
         await services.SaveAccountAsync(grant.Account, ctx.Ct);
 
-        return new(TMessageCodec.EncodeBuyGoodsRet(grant.Reward, arg.GoodId, arg.BuyNum), true, "");
+        return new(TMessageCodec.EncodeBuyGoodsRet(grant.Reward, arg.GoodId, arg.BuyNum), true, "",
+            grant.Reward.Type == GameServices.GoodsTypeShip ? [grant.Reward.ConfigId] : null);
     }
 
     /// <summary>处理 shop.QualityBuyGoods（多选/批量购买）：对每个 GoodId 免费发放。</summary>
@@ -112,7 +116,9 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
         if (rewards.Count == 0) return new([], false, "shop goods were not found");
         await services.SaveAccountAsync(account, ctx.Ct);
 
-        return new(TMessageCodec.EncodeQualityBuyGoodsRet(rewards, arg.GoodIdList), true, "");
+        return new(TMessageCodec.EncodeQualityBuyGoodsRet(rewards, arg.GoodIdList), true, "",
+            rewards.Where(reward => reward.Type == GameServices.GoodsTypeShip)
+                .Select(reward => reward.ConfigId).ToList());
     }
 
     /// <summary>发放单个 GM 商品，返回更新后的账号和奖励。无效商品返回 Type=0 的空奖励。</summary>

--- a/src/BlueOath.Server/Protocols/Services/GameServices.cs
+++ b/src/BlueOath.Server/Protocols/Services/GameServices.cs
@@ -324,6 +324,17 @@ internal sealed class GameServices
                     HeroMemoryList: CharacterStoryLoader.AllMemories)),
                 Time: now)),
 
+            // 图鉴「上一次快照」同步，必须紧跟在上面的全量图鉴推送之后。
+            // IllustrateData:IsFirstGetHero() 判定的是 oldCurrId（应用推送前的 currId），
+            // 而 SetIllustrateData 在登录这一次快照时 currId 还是空表，于是 oldCurrId 也为空，
+            // 任何舰船都会被判成首次获得。illustrate.OldIllustrateInfo 的客户端处理器忽略
+            // Ret，只把 oldCurrId 同步成当前 currId（该方法在 protobufTypeManager 中未注册
+            // 类型，不做 pb 解码，空 Ret 是安全的）。
+            TMessageCodec.EncodeResponse(new TResponse(
+                Method: "illustrate.OldIllustrateInfo",
+                Ret: [],
+                Time: now)),
+
             // 活动剧情回顾进度。Index 设为章节节点总数，使所有往期活动剧情均可重播。
             TMessageCodec.EncodeResponse(new TResponse(
                 Method: "illustrate.Memory",
@@ -1262,11 +1273,11 @@ internal sealed class GameServices
 
     /// <summary>购买数据推送（货币 + 仓库 + 时装 + 装备），必须在 shop.BuyGoods 应答前发出。</summary>
     public async Task<IReadOnlyList<byte[]>> BuildBuyPushesAsync(string profileId, uint now, CancellationToken ct,
-        IReadOnlyList<int>? removedBagTemplateIds = null)
+        IReadOnlyList<int>? removedBagTemplateIds = null, IReadOnlyList<int>? newShipTemplateIds = null)
     {
         var account = await GetOrCreateAccountAsync(profileId, ct);
         List<HeroGrid> heroes = account.Dock.Heroes.Select(ToHeroGrid).ToList();
-        return
+        List<byte[]> pushes =
         [
             await BuildUpdateUserInfoPushAsync(profileId, now, ct),
             // 购买舰娘后刷新船坞（hero.UpdateHeroBagData），使新船立即出现在船坞。
@@ -1274,10 +1285,30 @@ internal sealed class GameServices
                 Method: "hero.UpdateHeroBagData",
                 Ret: PlayerDataCodec.Encode(new HeroBag(heroes, account.Dock.BagSize)),
                 Time: now)),
-            BuildBagPush(account, now, removedBagTemplateIds),
-            BuildFashionPush(account, now),
-            BuildEquipPush(account, now),
         ];
+        // 购买舰娘还必须同步图鉴。客户端 IllustrateData 只在收到 illustrate.IllustrateInfo 时
+        // 才把 ship_info_id 并入 currId，并以「应用本次推送之前的 currId」作为 oldCurrId 快照；
+        // ShowGirlPage 的 bNew 取自 IsFirstGetHero()，判定的正是 oldCurrId。缺这条推送时该船
+        // 永远进不了 currId/oldCurrId，重复获得仍会播放首次获得动画、弹上锁询问并显示 NEW
+        // 角标，图鉴也要重登才解锁。
+        if (newShipTemplateIds is { Count: > 0 })
+        {
+            pushes.Add(TMessageCodec.EncodeResponse(new TResponse(
+                Method: "illustrate.IllustrateInfo",
+                Ret: PlayerDataCodec.Encode(new IllustrateInfoRet(
+                    IllustrateList: newShipTemplateIds
+                        .Select(ToIllustrateId)
+                        .Distinct()
+                        .Select(illustrateId => BuildUnlockedIllustrateInfo(illustrateId, now))
+                        .ToList(),
+                    // repeated 字段必须非 nil，否则客户端 ipairs(nil) 崩溃。
+                    IllustrateEquipList: [new IllustrateEquipInfo()])),
+                Time: now)));
+        }
+        pushes.Add(BuildBagPush(account, now, removedBagTemplateIds));
+        pushes.Add(BuildFashionPush(account, now));
+        pushes.Add(BuildEquipPush(account, now));
+        return pushes;
     }
 
     /// <summary>换装/买时装后的数据推送（船坞 + 装备仓库），供会话在 hero.ChangeEquip 应答后发出。</summary>

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -31,6 +31,7 @@ var tests = new (string Name, Func<Task> Run)[]
     ("building config, lifecycle and assignment codecs match the client", BuildingCodecTest),
     ("story unlock config includes event, side and personal stories", StoryUnlockConfigTest),
     ("illustrate entries unlock every configured behaviour", IllustrateBehaviourUnlockTest),
+    ("ship acquisition keeps the client illustrate snapshot in sync", ShipAcquisitionIllustrateSyncTest),
     ("Mubar battle start preserves CopyType 33", MubarBattleStartCodecTest),
     ("sea-copy entries include non-nil safe-area state", SeaCopySafeAreaCodecTest),
     ("illustrate payload encodes unlocked personal stories", HeroMemoryCodecTest),
@@ -127,6 +128,67 @@ foreach (var (name, run) in tests)
     catch (Exception e) { failed++; Console.Error.WriteLine($"FAIL {name}: {e.Message}"); }
 }
 return failed;
+
+// 客户端 IllustrateData:IsFirstGetHero() 判定的是 oldCurrId —— 应用某次 illustrate.IllustrateInfo
+// 之前的 currId 快照。ShowGirlPage 的 bNew（首次获得动画、上锁询问、NEW 角标）全部取自它。
+// 因此两件事必须成立，否则重复获得的舰船会被当成首次获得：
+//   1. 登录全量图鉴推送之后要补一条 illustrate.OldIllustrateInfo，把 oldCurrId 从空表同步成
+//      currId；登录时 currId 尚为空，SetIllustrateData 快照出来的 oldCurrId 必然是空的。
+//   2. 商店发放舰娘时要推 illustrate.IllustrateInfo，否则该 ship_info_id 永远进不了 currId。
+static async Task ShipAcquisitionIllustrateSyncTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-illustrate-sync-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "illustrate-sync";
+    const int shipTemplateId = 40110311;
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        await repo.SaveAccountAsync(PlayerAccountFactory.CreateDefault(profileId, 1) with
+        {
+            Dock = new HeroDock([new Hero(10, 10210511, 5)]),
+        });
+
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+
+        List<string> loginMethods = (await services.BuildSyncPushesAsync(profileId, 1, CancellationToken.None))
+            .Select(push => TMessageCodec.DecodeResponse(push).Method ?? "").ToList();
+        int infoIndex = loginMethods.IndexOf("illustrate.IllustrateInfo");
+        int oldIndex = loginMethods.IndexOf("illustrate.OldIllustrateInfo");
+        Assert(infoIndex >= 0 && oldIndex >= 0,
+            "login snapshot did not seed the client illustrate baseline");
+        Assert(oldIndex > infoIndex,
+            "illustrate.OldIllustrateInfo must follow the full illustrate snapshot it takes a copy of");
+
+        List<string> plainMethods =
+            (await services.BuildBuyPushesAsync(profileId, 1, CancellationToken.None))
+            .Select(push => TMessageCodec.DecodeResponse(push).Method ?? "").ToList();
+        Assert(!plainMethods.Contains("illustrate.IllustrateInfo"),
+            "a purchase without ships should not push illustrate data");
+
+        IReadOnlyList<byte[]> shipPushes = await services.BuildBuyPushesAsync(
+            profileId, 1, CancellationToken.None, newShipTemplateIds: [shipTemplateId]);
+        List<TResponse> shipResponses = shipPushes.Select(push => TMessageCodec.DecodeResponse(push)).ToList();
+        Assert(shipResponses.Any(push => push.Method == "hero.UpdateHeroBagData"),
+            "buying a ship did not refresh the dock");
+        TResponse illustratePush = shipResponses.SingleOrDefault(p => p.Method == "illustrate.IllustrateInfo")
+            ?? throw new InvalidDataException("buying a ship did not push illustrate data");
+        // IllustrateId = ship_info_id = (templateId - 1) / 10，客户端据此把该船并入 currId。
+        byte[] expected = new ProtocolPackage().Write(0x08, (ulong)((shipTemplateId - 1) / 10)).ToArray();
+        Assert(illustratePush.Ret is { Length: > 0 } && ContainsSequence(illustratePush.Ret, expected),
+            "illustrate push did not carry the purchased ship's illustrate id");
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
+}
 
 static async Task HeroAdvanceStateTest()
 {


### PR DESCRIPTION
修复 #65。

## 改动

1. **`BuildSyncPushesAsync`：登录全量图鉴推送之后补发一条 `illustrate.OldIllustrateInfo`**，把 `oldCurrId` 播种为完整的已有集合。该方法在客户端 `protobufTypeManager` 中**未注册 pb 类型**（`pbType` 为 nil，不做解码），处理器也完全忽略 `Ret`，发空 `Ret` 是安全的。顺序必须在全量推送**之后** —— 它复制的正是那次推送写入的 `currId`。
2. **`BuildBuyPushesAsync`：新增可选参数 `newShipTemplateIds`**，非空时补发与 `BuildShipModule` 同款的增量 `illustrate.IllustrateInfo`（`IllustrateEquipList` 保持非 nil，否则客户端 `ipairs(nil)` 崩溃）。
3. **`ShopModule`：`PurchaseResult` 增加 `ShipTemplateIds`**，`BuyGoods` / `QualityBuyGoods` 两条路径分别收集 `Type == GoodsTypeShip` 的 `ConfigId` 并透传给推送侧。

严格说只要每条获取路径都推图鉴就不需要第 1 条，但有它之后任何遗漏路径都不会再退化成「全部判新」，成本也只是一条空推送。

**注**： 本分支没有动 `native/Payload/lua_mod_loader.cpp`

## 预期行为

修复了 R/N 品质重复船的误弹。

## 附：`06016c5` 的 native 补丁为何没有生效

issue 里没提这段。`native/Payload/lua_mod_loader.cpp` 里针对同一现象的那个补丁实际没起作用，所以本 PR 走的是服务端路线；把分析附在这里，方便判断要不要把那段钩子回退掉。

`native/Payload/lua_mod_loader.cpp` 里针对同一现象的补丁（*fix:修复了当重复抽到船时仍然提示新船锁定的问题*）实际一行都没起作用。

先排除环境因素：整合包中的 `BlueOath.Payload.dll` 编译于该提交**之后**（提交 `08-30 10:26`，DLL `08-30 12:38`），`BlueOath.Payload.log` 里两条安装日志也都在：

```
[LuaModLoader] native BuildShipLogic new-state capture installed
[LuaModLoader] native ShowGirlPage new-state forwarding installed
```

逻辑本身没有成立：

**1. 写错了表。** 补丁执行 `showGirlSetField(state, paramIndex, "bNew")`，即 `self.param.bNew`；而页面读的是 `self.bNew`（`showgirlpage.lua` 第 55、162、298、449 行）。在全部 **1526 个** Lua 字节码中检索 `bNew` 字符串，只有 `showgirlpage.lua`（该字段本身）和 `equipchangepage.lua`（装备页，无关）两处命中 —— **没有任何代码读 `param.bNew`**。

**2. 即使写对也会被覆盖。** 补丁在调用原函数**之前**赋值，而原版 `_UpdatePage`（第 120 行）在第 162 行无条件重算 `self.bNew = Logic.illustrateLogic:IsFirstGetHero(self.girlId)`，顺序天然是反的。

**3. 判据只覆盖建造一条路。** 门槛是 `pendingBuildShipNewValid && hasBuildNum && !hasGetWay`，而 `ShowGirlPage` 至少有四个入口：

| 入口 | 参数 | 过门槛？ |
|---|---|---|
| 建造 | `{..., buildNum}` | ✅ |
| 战斗掉落 `droprewardshelper.lua:17` | `{girlId, HeroId}` | ❌ 无 `buildNum` |
| 奖励/剧情 `rewardlogic.lua:176` | `{girlId, HeroId, getWay, ...}` | ❌ 无 `buildNum`，且有 `getWay` |
| 战斗结算 `settlementlogic.lua:330` | `{..., getWay = battle}` | ❌ 同上 |

而且 `CheckShowMeet` 是 `BuildShipLogic` 独有的，非建造路径根本不会调用，`pendingBuildShipNewValid` 恒为 false。


### 可以无视

`HeroData:SetRecordNewHero` / `ShipLogic:IsNewShip`（船坞里按 HeroId 实例的 NEW 记录）在本版客户端中是死代码，全部 1526 个 Lua 文件里只有 `herodata.lua` 的定义，零调用点，`self.newHero` 永远为空。玩家看到的 NEW 角标全部来自 `ShowGirlPage` 的 `img_new`。

## 验证

新增用例断言：登录推送中 `OldIllustrateInfo` 排在全量图鉴之后；无对应战姬时的商店购买行为不推图鉴；正确的发船的购买推送带 `IllustrateId`（`(templateId - 1) / 10`）。分别停用两处修复后复跑，用例各自以「login snapshot did not seed the client illustrate baseline」和「buying a ship did not push illustrate data」失败，确认可捕获回归。

本分支基于当前 `master`，套件里另有 2 条失败（`selected launcher profile ...` / `hero advance ...`），是 `master` 上原有的、与本改动无关，已由 #62 修复。

Fixes #65
