### PR TITLE
feat: 实现道具选择箱 bag.GetSelectTreasureInfo

### DIFF
--- a/src/BlueOath.Protocol/PlayerDataCodec.cs
+++ b/src/BlueOath.Protocol/PlayerDataCodec.cs
@@ -198,7 +198,15 @@ public sealed record BagInfoRet(int BagType = 0, int BagSize = 0, IReadOnlyList<
 /// <summary>普通宝箱使用参数（TBagNormalTreasureInfoArg）。</summary>
 public sealed record BagNormalTreasureInfoArg(int TreasureId = 0, int TreasureNum = 0);
 
-/// <summary>宝箱开启结果（TBagTreasureInfoRet）。</summary>
+/// <summary>
+/// 自选/随机选择箱使用参数（TBagSelectTreasureInfoArg）。
+/// Position 是 config_item_selected.item_id 中玩家所选项的序号，<b>从 1 开始</b>——
+/// 客户端 SelectRandTreasurePage 把它当 Lua 表下标直接用（item_id[self.pos]），
+/// 且初值就是 1。当该箱只配了 drop_id 而 item_id 为空时，客户端固定传 0，由服务端随机抽取。
+/// </summary>
+public sealed record BagSelectTreasureInfoArg(int TreasureId = 0, int Position = 0, int Num = 0);
+
+/// <summary>宝箱开启结果（TBagTreasureInfoRet）。自选箱与普通宝箱共用该响应。</summary>
 public sealed record BagTreasureInfoRet(
     IReadOnlyList<CommonReward>? TreasuresInfo = null, int TreasureId = 0);
 
@@ -952,6 +960,25 @@ var reader = new GameLoginCodec.ProtoReader(payload);
             }
         }
         return new BagNormalTreasureInfoArg(treasureId, treasureNum);
+    }
+
+    public static BagSelectTreasureInfoArg DecodeBagSelectTreasureInfoArg(ReadOnlySpan<byte> payload)
+    {
+        var treasureId = 0;
+        var position = 0;
+        var num = 0;
+        var reader = new GameLoginCodec.ProtoReader(payload);
+        while (reader.TryReadField(out var field, out var wire))
+        {
+            switch (field)
+            {
+                case 1 when wire == 0: treasureId = checked((int)reader.ReadVarint()); break;
+                case 2 when wire == 0: position = checked((int)reader.ReadVarint()); break;
+                case 3 when wire == 0: num = checked((int)reader.ReadVarint()); break;
+                default: reader.Skip(wire); break;
+            }
+        }
+        return new BagSelectTreasureInfoArg(treasureId, position, num);
     }
 
     public static byte[] Encode(BagTreasureInfoRet value)

--- a/src/BlueOath.Server/Protocols/ConfigLoaders.cs
+++ b/src/BlueOath.Server/Protocols/ConfigLoaders.cs
@@ -264,6 +264,19 @@ internal static class ItemInfoLoader
     }
 }
 
+/// <summary>
+/// 选择箱配置（config_item_selected，物品类型 8）。item_id 为 [GoodsType, ConfigId, Num]
+/// 三元组列表，玩家按下标选择其一；item_id 为空而 drop_id &gt; 0 的条目是随机选择箱。
+/// type：1=舰船箱 2=装备箱 3=道具箱 4=时装箱。
+/// </summary>
+internal static class ItemSelectedLoader
+{
+    public static Dictionary<int, ConfigItemSelected> Load(string configDir)
+    {
+        return ConfigDbLoader.LoadAll<ConfigItemSelected>(configDir, "config_item_selected.db");
+    }
+}
+
 internal static class ShipLevelupLoader
 {
     public static (Dictionary<int, int> ExpPerItem, Dictionary<int, int> ExpNeeded) Load(string configDir)

--- a/src/BlueOath.Server/Protocols/Modules/ShopModule.cs
+++ b/src/BlueOath.Server/Protocols/Modules/ShopModule.cs
@@ -59,6 +59,26 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
                         : [],
                 };
                 break;
+            case "bag.GetSelectTreasureInfo":
+                ShopService.TreasureOpenResult selected =
+                    await shop.BuildOpenSelectTreasureRetAsync(request, ctx.ProfileId, ctx.Ct);
+                // 非道具箱（舰船/装备选择箱）由 BuildOpenSelectTreasureRetAsync 返回
+                // Changed=false 且 Error 为空，此处保持改动前的空响应，不引入新的错误码。
+                result = !selected.Changed && selected.Error.Length == 0
+                    ? ModuleResult.Empty
+                    : new ModuleResult
+                    {
+                        Ret = selected.Ret,
+                        Err = selected.Changed ? 0 : 1,
+                        ErrMsg = selected.Error,
+                        PrePushes = selected.Changed
+                            ? await services.BuildBuyPushesAsync(ctx.ProfileId, (uint)ctx.Now, ctx.Ct,
+                                selected.RemovedTreasureTemplateId > 0
+                                    ? [selected.RemovedTreasureTemplateId]
+                                    : null)
+                            : [],
+                    };
+                break;
             case "shop.RefreshShop":
             default:
                 result = ModuleResult.Empty;
@@ -135,7 +155,7 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
         }
         else if (goods.Type == GameServices.GoodsTypeFashion)
         {
-            account = AddFashion(account, goods.ItemId);
+            account = services.AddFashion(account, goods.ItemId);
         }
         else if (goods.Type == GameServices.GoodsTypeShip)
         {
@@ -172,23 +192,4 @@ internal sealed class ShopModule(ShopService shop, GameServices services) : IGam
         return account with { Equip = equip with { Items = items } };
     }
 
-    private PlayerAccount AddFashion(PlayerAccount account, int fashionTid)
-    {
-        var fashion = account.Fashion ?? new PlayerFashion([]);
-        var entries = fashion.Entries.ToList();
-        var sfId = services.FashionSfIdMap.GetValueOrDefault(fashionTid, fashionTid);
-        var idx = entries.FindIndex(e => e.SfId == sfId);
-        if (idx >= 0)
-        {
-            var tids = entries[idx].FashionTids.ToList();
-            if (!tids.Contains(fashionTid))
-                tids.Add(fashionTid);
-            entries[idx] = entries[idx] with { FashionTids = tids };
-        }
-        else
-        {
-            entries.Add(new FashionEntry(sfId, [fashionTid]));
-        }
-        return account with { Fashion = fashion with { Entries = entries } };
-    }
 }

--- a/src/BlueOath.Server/Protocols/Services/GameServices.cs
+++ b/src/BlueOath.Server/Protocols/Services/GameServices.cs
@@ -34,6 +34,7 @@ internal sealed class GameServices
     private readonly Dictionary<int, ConfigExtractShip> _extractShips;
     private readonly Dictionary<int, ConfigDropItem> _dropItems;
     private readonly Dictionary<int, ConfigItemInfo> _itemInfos;
+    private readonly Dictionary<int, ConfigItemSelected> _itemSelected;
     private readonly Dictionary<int, ConfigSpecialdraw> _specialDraws;
     private readonly Dictionary<int, ConfigShipInfo> _shipInfos;
     private readonly Dictionary<int, int> _expPerItem;
@@ -67,6 +68,7 @@ internal sealed class GameServices
         ConstructionConfigLoader.Load(configDir);
         BuildingConfigLoader.Load(configDir);
         _itemInfos = ItemInfoLoader.Load(configDir);
+        _itemSelected = ItemSelectedLoader.Load(configDir);
         (_expPerItem, _expNeeded) = ShipLevelupLoader.Load(configDir);
         _copyRandomFactors = RandomFactorLoader.Load(configDir);
         ChapterCopyLoader.Load(configDir);
@@ -119,6 +121,7 @@ internal sealed class GameServices
 
     /// <summary>道具配置（宝箱道具通过 DropId 指向 config_drop_item）。</summary>
     internal IReadOnlyDictionary<int, ConfigItemInfo> ItemInfos => _itemInfos;
+    internal IReadOnlyDictionary<int, ConfigItemSelected> ItemSelected => _itemSelected;
 
     /// <summary>船信息配置（供 BuildShipService）。</summary>
     internal IReadOnlyDictionary<int, ConfigShipInfo> ShipInfos => _shipInfos;
@@ -711,6 +714,30 @@ internal sealed class GameServices
     /// <summary>序列化 GUIDE_DONE_STAGES（Serialize 生成的字符串，key 为字符串）。</summary>
     private static string BuildDoneGuideStages() =>
         "{" + string.Join(",", DoneGuideStages.Select(id => $"[\"{id}\"]=1")) + "}";
+
+    /// <summary>
+    /// 时装解锁：按 config_ship_info.sf_id 归组写入玩家时装表，重复解锁不会产生重复项。
+    /// 商店购买与选择箱开启共用（选择箱的道具类里含时装奖励，不能走 AddBagItem）。
+    /// </summary>
+    internal PlayerAccount AddFashion(PlayerAccount account, int fashionTid)
+    {
+        var fashion = account.Fashion ?? new PlayerFashion([]);
+        var entries = fashion.Entries.ToList();
+        var sfId = FashionSfIdMap.GetValueOrDefault(fashionTid, fashionTid);
+        var idx = entries.FindIndex(e => e.SfId == sfId);
+        if (idx >= 0)
+        {
+            var tids = entries[idx].FashionTids.ToList();
+            if (!tids.Contains(fashionTid))
+                tids.Add(fashionTid);
+            entries[idx] = entries[idx] with { FashionTids = tids };
+        }
+        else
+        {
+            entries.Add(new FashionEntry(sfId, [fashionTid]));
+        }
+        return account with { Fashion = fashion with { Entries = entries } };
+    }
 
     /// <summary>设置装备的 HeroId（装备/卸下）。</summary>
     internal static PlayerAccount SetEquipHeroId(PlayerAccount account, uint equipId, uint heroId)

--- a/src/BlueOath.Server/Protocols/Services/ShopService.cs
+++ b/src/BlueOath.Server/Protocols/Services/ShopService.cs
@@ -1,5 +1,6 @@
 using BlueOath.Core;
 using BlueOath.Protocol;
+using BlueOath.Server.Configs;
 
 namespace BlueOath.Server.Protocols;
 
@@ -88,6 +89,95 @@ internal sealed class ShopService(GameServices services)
                 account = GameServices.AddBagItem(account, reward.ConfigId, reward.Num);
                 rewards.Add(new CommonReward(reward.Type, reward.ConfigId, reward.Num));
             }
+        }
+
+        await services.SaveAccountAsync(account, ct);
+        byte[] ret = PlayerDataCodec.Encode(new BagTreasureInfoRet(rewards, arg.TreasureId));
+        // bag.UpdateBagData 是增量合并；完全耗尽时必须额外推送 Num=0 才会从客户端仓库删除。
+        return new(ret, true, "", remaining == 0 ? arg.TreasureId : 0);
+    }
+
+    /// <summary>config_item_selected.type：3 = 道具箱（本方法只处理这一类）。</summary>
+    private const int SelectedTypeItem = 3;
+
+    /// <summary>
+    /// 开启道具选择箱（bag.GetSelectTreasureInfo）。
+    ///
+    /// 客户端 SelectRandTreasurePage:_ClickSure 发来 {treasureId, position, num}，position 是
+    /// config_item_selected.item_id 的下标；item_id 为空而 drop_id &gt; 0 时是随机选择箱，
+    /// 客户端固定传 position=0，由服务端从掉落池抽取。
+    ///
+    /// 只处理 type == 3 的道具箱：舰船箱（type 1）与装备箱（type 2）另有实现，此处返回
+    /// Changed=false 且不带错误，交由调用方保持原有的空响应，行为与改动前一致。
+    /// </summary>
+    internal async Task<TreasureOpenResult> BuildOpenSelectTreasureRetAsync(
+        TRequest request, string profileId, CancellationToken ct)
+    {
+        if (request.Args is null) return new([], false, "select treasure request is missing");
+        BagSelectTreasureInfoArg arg = PlayerDataCodec.DecodeBagSelectTreasureInfoArg(request.Args);
+        int openNum = arg.Num <= 0 ? 1 : arg.Num;
+        // config_parameter[54]（box_open_num_max）规定单次最多开启 99 个。
+        if (arg.TreasureId <= 0 || openNum > 99)
+            return new([], false, "select treasure id or count is invalid");
+        if (!services.ItemSelected.TryGetValue(arg.TreasureId, out ConfigItemSelected? config))
+            return new([], false, "select treasure configuration was not found");
+        // 非道具箱不在本次实现范围内，保持原有空响应。
+        if (config.Type != SelectedTypeItem) return new([], false, "");
+
+        List<List<long>> options = config.ItemId ?? [];
+        var pending = new List<PendingReward>();
+        if (options.Count > 0)
+        {
+            // Position 由客户端按 Lua 表下标下发，从 1 开始计数。
+            if (arg.Position < 1 || arg.Position > options.Count)
+                return new([], false, "select treasure position is out of range");
+            List<long> option = options[arg.Position - 1];
+            if (option.Count < 3) return new([], false, "select treasure option is malformed");
+            int type = checked((int)option[0]);
+            int configId = checked((int)option[1]);
+            int num = checked((int)option[2]);
+            if (num <= 0) return new([], false, "select treasure option has a non-positive count");
+            // 舰船/装备的发放路径本次不动，避免与既有实现产生分歧。
+            if (type is GameServices.GoodsTypeShip or GameServices.GoodsTypeEquip)
+                return new([], false, "select treasure option type is not supported yet");
+            for (var i = 0; i < openNum; i++) pending.Add(new PendingReward(type, configId, num));
+        }
+        else
+        {
+            if (config.DropId <= 0) return new([], false, "select treasure has neither options nor a drop pool");
+            for (var i = 0; i < openNum; i++)
+            {
+                if (!TryDrawPool(checked((int)config.DropId), pending, [], 0))
+                    return new([], false, "select treasure drop pool is invalid");
+            }
+            if (pending.Any(x => x.Type is GameServices.GoodsTypeShip or GameServices.GoodsTypeEquip))
+                return new([], false, "select treasure reward type is not supported yet");
+        }
+
+        using var _ = await services.LockAccountAsync(profileId, ct);
+        PlayerAccount account = await services.GetOrCreateAccountAsync(profileId, ct);
+        PlayerBag bag = account.Bag ?? new PlayerBag([], 100);
+        int bagIndex = bag.Items.ToList().FindIndex(x => x.TemplateId == arg.TreasureId);
+        if (bagIndex < 0 || bag.Items[bagIndex].Num < openNum)
+            return new([], false, "select treasure count is insufficient");
+
+        var bagItems = bag.Items.ToList();
+        int remaining = bagItems[bagIndex].Num - openNum;
+        if (remaining == 0) bagItems.RemoveAt(bagIndex);
+        else bagItems[bagIndex] = bagItems[bagIndex] with { Num = remaining };
+        account = account with { Bag = bag with { Items = bagItems } };
+
+        var rewards = new List<CommonReward>();
+        foreach (PendingReward reward in pending)
+        {
+            if (reward.Type == GameServices.GoodsTypeCurrency)
+                account = GameServices.AddCurrency(account, reward.ConfigId, reward.Num);
+            else if (reward.Type == GameServices.GoodsTypeFashion)
+                // 道具箱里含时装奖励；走 AddBagItem 会让客户端按道具配置解析时装模板而出错。
+                for (var i = 0; i < reward.Num; i++) account = services.AddFashion(account, reward.ConfigId);
+            else
+                account = GameServices.AddBagItem(account, reward.ConfigId, reward.Num);
+            rewards.Add(new CommonReward(reward.Type, reward.ConfigId, reward.Num));
         }
 
         await services.SaveAccountAsync(account, ct);

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -42,6 +42,7 @@ var tests = new (string Name, Func<Task> Run)[]
     ("mod manager filters target and orders mods", ModTest),
     ("equipment mod adds a client/server template and GM shop good", EquipmentModTest),
     ("fashion shop previews tolerate an unlocked skin without its hero", FashionPreviewModTest),
+    ("item selection boxes grant the chosen option", SelectTreasureTest),
     ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest)
 };
 if (args.Contains("--integration", StringComparer.OrdinalIgnoreCase)) tests = [.. tests,
@@ -2705,6 +2706,116 @@ static Task SeaCopySafeAreaCodecTest()
 
     Assert(foundSafeAreaCopy, "sea-copy synchronization did not include safe-area copy 5011");
     return Task.CompletedTask;
+}
+
+// 自选箱（config_item_selected，物品类型 8）此前完全没有服务端实现：bag.GetSelectTreasureInfo
+// 落到 ShopModule 的 default 分支返回空 Ret 且 Err=0，客户端 SelectRandTreasurePage 解出空的
+// treasuresInfo，表现为「选好点确认后什么都没有」。
+// item_id 是 [GoodsType, ConfigId, Num] 三元组列表；position 是其中的序号，<b>从 1 开始</b>：
+// 客户端 SelectRandTreasurePage 把它当 Lua 表下标直接用（item_id[self.pos]），初值即为 1。
+// 按 0 基解析会整体偏移一位——选第 1 项拿到第 2 项，选末项则越界被拒。
+// 本次只实现 type==3 的道具箱；type 1/2（舰船箱、装备箱）另有实现，必须保持空响应不变。
+static async Task SelectTreasureTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-select-box-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "select-box";
+    const int itemBoxId = 80134;     // 祈願特注石選択箱（精選版）：[[11,110037,18],[11,110050,18]]
+    const int fashionBoxId = 80240;  // 大破着せ替え+α選択箱：首项 [18,4044015,1]
+    const int shipBoxId = 80324;     // 指定戦姫チケット（限定版）：下标 0 是舰船
+    const int heroBoxId = 80001;     // 舰船箱（type=1），必须保持空响应
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        await repo.SaveAccountAsync(PlayerAccountFactory.CreateDefault(profileId, 1) with
+        {
+            Bag = new PlayerBag(
+            [
+                new BagItem(itemBoxId, 5),
+                new BagItem(fashionBoxId, 1),
+                new BagItem(shipBoxId, 1),
+                new BagItem(heroBoxId, 1),
+            ], 200),
+        });
+
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+        var shop = new ShopService(services);
+
+        static byte[] Args(int treasureId, int position, int num) => new ProtocolPackage()
+            .Write(0x08, (ulong)treasureId)
+            .Write(0x10, (ulong)position)
+            .Write(0x18, (ulong)num)
+            .ToArray();
+
+        // 80134 的选项是 [[11,110037,18],[11,110050,18]]。position=1 必须给第 1 项。
+        ShopService.TreasureOpenResult first = await shop.BuildOpenSelectTreasureRetAsync(
+            new TRequest("bag.GetSelectTreasureInfo", Args(itemBoxId, 1, 1)), profileId, CancellationToken.None);
+        Assert(first.Changed, $"item selection box was rejected at position 1: {first.Error}");
+        PlayerAccount afterFirst = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("select-box account disappeared");
+        Assert(afterFirst.Bag!.Items.Single(i => i.TemplateId == 110037).Num == 18,
+            "position 1 did not grant the first option (off-by-one in the option index?)");
+        Assert(afterFirst.Bag.Items.All(i => i.TemplateId != 110050),
+            "position 1 granted the second option instead of the first");
+        Assert(afterFirst.Bag.Items.Single(i => i.TemplateId == itemBoxId).Num == 4,
+            "item selection box consumed the wrong number of boxes");
+
+        // position=2 是该箱的末项，必须同样可选——按 0 基解析时这里会越界被拒。
+        ShopService.TreasureOpenResult last = await shop.BuildOpenSelectTreasureRetAsync(
+            new TRequest("bag.GetSelectTreasureInfo", Args(itemBoxId, 2, 1)), profileId, CancellationToken.None);
+        Assert(last.Changed, $"the last option was rejected: {last.Error}");
+        PlayerAccount afterLast = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("select-box account disappeared");
+        Assert(afterLast.Bag!.Items.Single(i => i.TemplateId == 110050).Num == 18,
+            "the last option did not grant its reward");
+
+        // 两侧越界都必须被拒绝，且不能扣除箱子。
+        foreach (int badPosition in new[] { 0, 3 })
+        {
+            ShopService.TreasureOpenResult outOfRange = await shop.BuildOpenSelectTreasureRetAsync(
+                new TRequest("bag.GetSelectTreasureInfo", Args(itemBoxId, badPosition, 1)),
+                profileId, CancellationToken.None);
+            Assert(!outOfRange.Changed,
+                $"item selection box accepted an out-of-range position {badPosition}");
+            PlayerAccount afterBad = await repo.LoadAccountAsync(profileId)
+                ?? throw new InvalidDataException("select-box account disappeared");
+            Assert(afterBad.Bag!.Items.Single(i => i.TemplateId == itemBoxId).Num == 3,
+                $"a rejected selection at position {badPosition} still consumed a box");
+        }
+
+        // 时装奖励必须进时装表，不能按道具入包。
+        ShopService.TreasureOpenResult fashion = await shop.BuildOpenSelectTreasureRetAsync(
+            new TRequest("bag.GetSelectTreasureInfo", Args(fashionBoxId, 1, 1)), profileId, CancellationToken.None);
+        Assert(fashion.Changed, $"fashion option was rejected: {fashion.Error}");
+        PlayerAccount afterFashion = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("select-box account disappeared");
+        Assert(afterFashion.Fashion?.Entries.Any(e => e.FashionTids.Contains(4044015)) == true,
+            "fashion option did not unlock the skin");
+        Assert(afterFashion.Bag!.Items.All(i => i.TemplateId != 4044015),
+            "fashion option polluted the item bag");
+
+        // 舰船选项本次不实现，必须明确拒绝而不是静默发放。
+        ShopService.TreasureOpenResult ship = await shop.BuildOpenSelectTreasureRetAsync(
+            new TRequest("bag.GetSelectTreasureInfo", Args(shipBoxId, 1, 1)), profileId, CancellationToken.None);
+        Assert(!ship.Changed && ship.Error.Length > 0,
+            "ship option inside an item box should be rejected with an error");
+
+        // 舰船箱（type=1）必须维持改动前的空响应：Changed=false 且 Error 为空。
+        ShopService.TreasureOpenResult heroBox = await shop.BuildOpenSelectTreasureRetAsync(
+            new TRequest("bag.GetSelectTreasureInfo", Args(heroBoxId, 1, 1)), profileId, CancellationToken.None);
+        Assert(!heroBox.Changed && heroBox.Error.Length == 0,
+            "hero selection box must keep its previous empty response");
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
 }
 
 static string FindClientConfigDir()


### PR DESCRIPTION
修复 #67。

## 改动

- **`PlayerDataCodec`**：新增 `BagSelectTreasureInfoArg(TreasureId = 1, Position = 2, Num = 3)` 与解码；响应完全复用既有的 `BagTreasureInfoRet` 编码。
- **`ConfigLoaders`**：新增 `ItemSelectedLoader` 加载 `config_item_selected.db`；`GameServices` 加载并以 `ItemSelected` 暴露。
- **`ShopService.BuildOpenSelectTreasureRetAsync`**：骨架沿用 `BuildOpenNormalTreasureRetAsync`（扣道具、装备仓库容量校验、`Num=0` 删除标记、经 `BuildBuyPushesAsync` 刷新客户端），只替换「取奖励」一步：`item_id` 非空则按 `position - 1` 取该项，否则走既有的 `TryDrawPool`。
- **`ShopModule`**：新增 `case "bag.GetSelectTreasureInfo"`。
- 时装类奖励走时装解锁而不是 `AddBagItem`，为此把 `AddFashion` 由 `ShopModule` 的私有方法提升到 `GameServices`，商店购买与开箱共用。

## 范围

只实现 `type == 3` 的道具箱。其余类型返回 `Changed = false` 且 `Error` 为空，由 `ShopModule` 维持 `ModuleResult.Empty`，舰船箱与装备箱的行为与改动前逐字节一致。

道具箱内的舰船奖励暂未处理（仅 `80261` 第 24 项、`80324` 第 1 项两处），对这两项返回明确错误而不是静默发放，同箱其余选项不受影响。战姬获取渠道稳定，开箱子获取的手段个人觉得可以忽略，所以这里没加进去。

## 验证

新增用例覆盖：`position = 1` 给第 1 项且不给第 2 项；`position = Count`（末项）成功；`position = 0` 与 `Count + 1` 两侧越界被拒且不扣箱子；时装进时装表而不污染背包；舰船选项被明确拒绝；舰船箱（`type = 1`）维持空响应。

临时把序号改回 0 基后复跑，用例以 `Sequence contains no matching element` 失败，确认能捕获该偏移。

已 rebase 到 `e0d963d`。30 个用例中 29 通过，唯一失败是 `selected launcher profile flows through bootstrap login responses`——`master` 上原有的 getPlData 断言问题，与本改动无关（见 #61）。0 警告 0 错误。

补充一句合并注意事项：这次的冲突只在 `src/BlueOath.Tests/Program.cs`，因为新用例原本插在`IllustrateBehaviourUnlockTest` 之后，方法体在 `HeroAdvanceStateTest` 之前——和 #66 的 `ShipAcquisitionIllustrateSyncTest` 是同一个位置，git 会把两个结构相似的相邻方法交织起来（#64 合并时 `GachaPoolRateTest` 就是这样被并坏的）。本次已把用例登记改为追加到数组末尾、方法体移到文件尾部 `FindClientConfigDir()` 之前，避开该锚点。

Fixes #67
