### PR TITLE
fix: getPlData 断言改读 data.pid

### DIFF
--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -881,7 +881,10 @@ static Task AccountProfileBootstrapTest()
 
     using JsonDocument plData = JsonDocument.Parse(
         responder.BuildResponse("GET /phone/getPlData/getPlData HTTP/1.1").Body);
-    Assert(plData.RootElement.GetProperty("pid").GetString() == profileId,
+    // 事件 1007 的信封是 errornu/errordesc/data，平台字段（含 pid）都在 data 之下，
+    // 见 BootstrapHttpResponder 的 getPlData 分支；摊到根对象会让 SDK 走 111111
+    // 未知错误分支，因此响应体是对的，断言需跟随该结构。
+    Assert(plData.RootElement.GetProperty("data").GetProperty("pid").GetString() == profileId,
         "getPlData did not expose selected profile");
 
     using JsonDocument login = JsonDocument.Parse(


### PR DESCRIPTION
AccountProfileBootstrapTest 断言 plData.RootElement.GetProperty("pid")，但 BootstrapHttpResponder 的 getPlData 分支返回的信封是 errornu/errordesc/data， pid 等平台字段都在 data 之下。根对象没有 pid，GetProperty("pid") 必然抛 KeyNotFoundException，该用例在 master 上是失败的：

  FAIL selected launcher profile flows through bootstrap login responses:
       The given key was not present in the dictionary.

铸币了，合并资源合并错地方，现在改好了(。

所以只改断言，然后补了一段注释说明这个结构。

同一函数里紧接着的 hash.RootElement.GetProperty("pid")（gethash 分支）是对的，那个响应确实把pid放在根对象，没有一起改。

改动后测试套件 29 个用例全部通过。

Fixes #61