### PR TITLE
fix: 测试项目在 master 上编译不过（ref struct 出现在 async 方法里）

### DIFF
--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -2914,28 +2914,8 @@ static async Task DailyCopyGameplayTest()
     Assert(ProtocolDecoder.DecodeVarintField(startPayload, 7) == 9,
         "copy.StartBase did not preserve DailyCopy type 9");
 
-    byte[] copyPayload = ProtocolEncoder.EncodeDailyCopyInfo();
-    int baseInfoCount = 0;
-    bool foundFirstDestroyerLevel = false, foundDestroyerTreaty = false;
-    ProtocolDecoder.ProtoReader copyReader = new(copyPayload);
-    while (copyReader.TryReadField(out int field, out int wire))
-    {
-        if (field != 1 || wire != 2)
-        {
-            copyReader.Skip(wire);
-            continue;
-        }
-        baseInfoCount++;
-        int baseId = 0;
-        ProtocolDecoder.ProtoReader baseInfo = new(copyReader.ReadBytes());
-        while (baseInfo.TryReadField(out int baseField, out int baseWire))
-        {
-            if (baseField == 1 && baseWire == 0) baseId = checked((int)baseInfo.ReadVarint());
-            else baseInfo.Skip(baseWire);
-        }
-        if (baseId == 20101) foundFirstDestroyerLevel = true;
-        if (baseId == 20518) foundDestroyerTreaty = true;
-    }
+    var (baseInfoCount, foundFirstDestroyerLevel, foundDestroyerTreaty) =
+        ScanDailyCopyInfo(ProtocolEncoder.EncodeDailyCopyInfo());
     Assert(baseInfoCount == 44 && foundFirstDestroyerLevel && foundDestroyerTreaty,
         "DailyCopy synchronization omitted configured normal or treaty levels");
 
@@ -2988,20 +2968,8 @@ static async Task DailyCopyGameplayTest()
             "destroyer treaty clear did not increment daily group success count");
         await services.SaveAccountAsync(account, CancellationToken.None);
 
-        byte[] statePayload = DailyCopyService.EncodeSnapshot(account.DailyCopy, today);
-        int chapterRows = 0, groupRows = 0, extraRows = 0;
-        ProtocolDecoder.ProtoReader stateReader = new(statePayload);
-        while (stateReader.TryReadField(out int stateField, out int stateWire))
-        {
-            if (stateWire == 2 && stateField is >= 1 and <= 3)
-            {
-                _ = stateReader.ReadBytes();
-                if (stateField == 1) chapterRows++;
-                else if (stateField == 2) groupRows++;
-                else extraRows++;
-            }
-            else stateReader.Skip(stateWire);
-        }
+        var (chapterRows, groupRows, extraRows) =
+            CountDailyCopySnapshotRows(DailyCopyService.EncodeSnapshot(account.DailyCopy, today));
         Assert(chapterRows == 4 && groupRows == 4 && extraRows == 4,
             "dailycopy.UpdateDailyCopyData omitted a repeated array required by the client");
 
@@ -3165,6 +3133,52 @@ static Task TaskCompletionRequiresProgressTest()
     Assert(TaskProtocolCodec.GetEventProgress([definition], partialProgress) == 2,
         "partial task event progress was not preserved");
     return Task.CompletedTask;
+}
+
+// ProtocolDecoder.ProtoReader 是 ref struct，C# 12 不允许它出现在 async 方法体内
+// （CS8652）。DailyCopyGameplayTest 是 async，两处解析必须提到独立的同步方法里。
+static (int BaseInfoCount, bool FirstDestroyerLevel, bool DestroyerTreaty) ScanDailyCopyInfo(byte[] copyPayload)
+{
+    int baseInfoCount = 0;
+    bool foundFirstDestroyerLevel = false, foundDestroyerTreaty = false;
+    ProtocolDecoder.ProtoReader copyReader = new(copyPayload);
+    while (copyReader.TryReadField(out int field, out int wire))
+    {
+        if (field != 1 || wire != 2)
+        {
+            copyReader.Skip(wire);
+            continue;
+        }
+        baseInfoCount++;
+        int baseId = 0;
+        ProtocolDecoder.ProtoReader baseInfo = new(copyReader.ReadBytes());
+        while (baseInfo.TryReadField(out int baseField, out int baseWire))
+        {
+            if (baseField == 1 && baseWire == 0) baseId = checked((int)baseInfo.ReadVarint());
+            else baseInfo.Skip(baseWire);
+        }
+        if (baseId == 20101) foundFirstDestroyerLevel = true;
+        if (baseId == 20518) foundDestroyerTreaty = true;
+    }
+    return (baseInfoCount, foundFirstDestroyerLevel, foundDestroyerTreaty);
+}
+
+static (int ChapterRows, int GroupRows, int ExtraRows) CountDailyCopySnapshotRows(byte[] statePayload)
+{
+    int chapterRows = 0, groupRows = 0, extraRows = 0;
+    ProtocolDecoder.ProtoReader stateReader = new(statePayload);
+    while (stateReader.TryReadField(out int stateField, out int stateWire))
+    {
+        if (stateWire == 2 && stateField is >= 1 and <= 3)
+        {
+            _ = stateReader.ReadBytes();
+            if (stateField == 1) chapterRows++;
+            else if (stateField == 2) groupRows++;
+            else extraRows++;
+        }
+        else stateReader.Skip(stateWire);
+    }
+    return (chapterRows, groupRows, extraRows);
 }
 
 static string FindClientConfigDir()


### PR DESCRIPTION
在未改动的 `master`（`0d7560e`）上，`src/BlueOath.Tests` 编译不过：

```
Program.cs(2920,5): error CS8652: 功能"异步方法和迭代器方法中的 ref 和 unsafe"当前为预览版且*不受支持*
Program.cs(2930,9): error CS8652
Program.cs(2993,9): error CS8652
```

`DailyCopyGameplayTest` 是 `async Task`，方法体内两处直接使用了 ref struct 的 `ProtocolDecoder.ProtoReader`（`copyReader` / `stateReader` 及各自的子读取器）。C# 12 不允许 ref struct 局部变量出现在 async 方法体内，整个测试项目因此无法构建，套件跑不起来。

## 改动

把两段解析提取为独立的同步方法：

- `ScanDailyCopyInfo(byte[] copyPayload)` → `(BaseInfoCount, FirstDestroyerLevel, DestroyerTreaty)`
- `CountDailyCopySnapshotRows(byte[] statePayload)` → `(ChapterRows, GroupRows, ExtraRows)`

**解析逻辑与断言逐字未改**，只是把 ref struct 的使用移出了 async 方法体，调用处改成接收返回的元组。

## 验证

改动后测试项目正常构建，全套 34 个用例通过，0 警告 0 错误。

## 说明

这是我在做 #73 时被挡住才发现的，与那个功能无关，所以按流程单独提出来。#73 的PR里动 `Program.cs` 的部分都要等这个先合，否则它自己的 CI 也构建不了测试项目。
