### PR TITLE
feat: 实现舰船强化与 guide.Setting 用户设置持久化

### DIFF
--- a/src/BlueOath.Core/PlayerEntities.cs
+++ b/src/BlueOath.Core/PlayerEntities.cs
@@ -258,7 +258,13 @@ public sealed record PlayerAccount(
     PlayerTalent? Talent = null,
     PlayerBuildState? BuildState = null,
     PlayerDailyCopyProgress? DailyCopy = null,
-    PlayerTaskProgress? Tasks = null);
+    PlayerTaskProgress? Tasks = null,
+    /// <summary>
+    /// guide.Setting 通道保存的全局用户设置（TGuideSetting 的 Key/Value 均为字符串）。
+    /// 强化页的三个开关 LOGIC_HERO_INTENSIFY_TypeMatchCancel / _RHeroSelect / _MORESELECT
+    /// 都存在这里，客户端只通过 GuideData:GetSettingByKey 读取。
+    /// </summary>
+    IReadOnlyDictionary<string, string>? UserSettings = null);
 
 /// <summary>
 /// 账号实体的默认工厂：集中定义新档案的初始角色与船坞，便于后续调整默认数值。

--- a/src/BlueOath.Core/PlayerEntities.cs
+++ b/src/BlueOath.Core/PlayerEntities.cs
@@ -73,7 +73,8 @@ public sealed record Hero(
     int AdvLv = 0,
     IReadOnlyList<PSkillEntry>? PSkills = null,
     IReadOnlyList<int>? RemouldEffects = null,
-    int RemouldLevel = 0);
+    int RemouldLevel = 0,
+    IReadOnlyList<AttrIntensify>? Intensify = null);
 
 /// <summary>
 /// 船坞（玩家拥有的全部舰娘）。对应 <c>hero.UpdateHeroBagData</c> 的 HeroBag

--- a/src/BlueOath.Protocol/PlayerDataCodec.cs
+++ b/src/BlueOath.Protocol/PlayerDataCodec.cs
@@ -25,6 +25,14 @@ public sealed class PSkillEntry
     }
 }
 
+/// <summary>
+/// 单条属性的强化进度（TAttrIntensify）。AttrType 为 config_attribute 的属性 id；
+/// IntensifyLvl 是已获得的强化等级——客户端 HeroAttr:_GetIntensify 按
+/// AddAttr(attrType, IntensifyLvl) 直接加算，即 1 级 = 1 点属性；
+/// CurExp 是当前等级内尚未凑满一级的强化值余量。
+/// </summary>
+public sealed record AttrIntensify(int AttrType = 0, int IntensifyLvl = 0, int CurExp = 0);
+
 /// <summary>Resources consumed by a single traditional build formula.</summary>
 public sealed record BuildItem(int ResId = 0, int Count = 0);
 
@@ -117,7 +125,7 @@ public sealed record HeroGrid(uint HeroId = 0, int TemplateId = 0, int Lvl = 0, 
     long CurHp = 0, int Mood = 0, int MarryType = 0, IReadOnlyList<uint>? EquipSlots = null, string Name = "",
     int ChangeNameTime = 0, bool Lock = false, int Advance = 0, int AdvLv = 0,
     IReadOnlyList<PSkillEntry>? PSkills = null, IReadOnlyList<int>? ArrRemouldEffect = null,
-    int RemouldLV = 0);
+    int RemouldLV = 0, IReadOnlyList<AttrIntensify>? Intensify = null);
 
 /// <summary>Payload for the <c>hero.UpdateHeroBagData</c> server message (THeroInfo).</summary>
 public sealed record HeroBag(IReadOnlyList<HeroGrid>? HeroInfo = null, int HeroBagSize = 0);
@@ -725,6 +733,22 @@ var reader = new GameLoginCodec.ProtoReader(payload);
         // Exp 必须无条件编码：girlinfo GirlShowPage._LoadPropertInfo 里
         // math.tointeger(Exp) .. "/" .. needExp 拼接，Exp 为 nil 会崩。
         WriteVarintField(output, 5, unchecked((ulong)value.Exp));
+        // Intensify (field 7, repeated TAttrIntensify)：舰船强化进度。客户端
+        // HeroAttr:_GetIntensify 遍历该数组并 AddAttr(AttrType, IntensifyLvl)，
+        // 字段缺失时 Lua 侧拿到空表、属性加成恒为 0（强化后数值不变）。
+        // 三个子字段无条件编码：strengthen_page 里 purelv * needExp 等算术直接使用
+        // IntensifyLvl/CurExp，取到 nil 会崩。
+        if (value.Intensify is { Count: > 0 } intensifyEntries)
+        {
+            foreach (AttrIntensify attr in intensifyEntries)
+            {
+                using var attrBody = new MemoryStream();
+                WriteVarintField(attrBody, 1, unchecked((ulong)attr.AttrType));
+                WriteVarintField(attrBody, 2, unchecked((ulong)attr.IntensifyLvl));
+                WriteVarintField(attrBody, 3, unchecked((ulong)attr.CurExp));
+                WriteMessage(output, 7, attrBody.ToArray());
+            }
+        }
         if (value.CreateTime != 0) WriteVarintField(output, 8, unchecked((ulong)value.CreateTime));
         if (value.CurHp != 0) WriteVarintField(output, 9, unchecked((ulong)value.CurHp));
         // PSkill (field 13, repeated TMapFiledPSkillExp)：编码所有实际技能数据。

--- a/src/BlueOath.Server/Protocols/ConfigLoaders.cs
+++ b/src/BlueOath.Server/Protocols/ConfigLoaders.cs
@@ -664,6 +664,56 @@ internal static class ShipBreakLoader
         _stages.TryGetValue(templateId, out ConfigShipBreak? config) ? config : null;
 }
 
+/// <summary>
+/// 舰船强化（hero.HeroIntensify）用到的三张表，键均为舰船 TemplateId（sm_id，随突破变化）：
+/// config_ship_need_power_exp    目标船每级所需强化值 + enhance_type（同型判定）
+/// config_ship_provide_power_exp 材料船各属性提供的强化值
+/// config_ship_max_power         各属性的强化等级上限
+/// </summary>
+internal static class ShipIntensifyLoader
+{
+    private static readonly Dictionary<int, ConfigShipNeedPowerExp> _need = new();
+    private static readonly Dictionary<int, ConfigShipProvidePowerExp> _provide = new();
+    private static readonly Dictionary<int, ConfigShipMaxPower> _max = new();
+    private static bool _loaded;
+
+    internal static void Load(string configDir)
+    {
+        if (_loaded) return;
+        try
+        {
+            _need.Clear();
+            _provide.Clear();
+            _max.Clear();
+            foreach (var (id, config) in ConfigDbLoader.LoadAll<ConfigShipNeedPowerExp>(
+                         configDir, "config_ship_need_power_exp.db"))
+                _need[id] = config;
+            foreach (var (id, config) in ConfigDbLoader.LoadAll<ConfigShipProvidePowerExp>(
+                         configDir, "config_ship_provide_power_exp.db"))
+                _provide[id] = config;
+            foreach (var (id, config) in ConfigDbLoader.LoadAll<ConfigShipMaxPower>(
+                         configDir, "config_ship_max_power.db"))
+                _max[id] = config;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ShipIntensify] load failed: {ex.Message}");
+        }
+        _loaded = true;
+    }
+
+    internal static ConfigShipNeedPowerExp? GetNeed(int templateId) =>
+        _need.TryGetValue(templateId, out ConfigShipNeedPowerExp? config) ? config : null;
+
+    internal static ConfigShipProvidePowerExp? GetProvide(int templateId) =>
+        _provide.TryGetValue(templateId, out ConfigShipProvidePowerExp? config) ? config : null;
+
+    internal static ConfigShipMaxPower? GetMax(int templateId) =>
+        _max.TryGetValue(templateId, out ConfigShipMaxPower? config) ? config : null;
+
+    internal static int Count => _need.Count;
+}
+
 internal static class AssistShipLoader
 {
     private static readonly Dictionary<int, ConfigAssistShipInfo> _ships = new();

--- a/src/BlueOath.Server/Protocols/Modules/GuideModule.cs
+++ b/src/BlueOath.Server/Protocols/Modules/GuideModule.cs
@@ -1,4 +1,5 @@
-﻿using BlueOath.Protocol;
+﻿using BlueOath.Core;
+using BlueOath.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BlueOath.Server.Protocols;
@@ -13,10 +14,39 @@ internal sealed class GuideModule(GameServices services) : IGameModule
         byte[] ret = request.Method switch
         {
             "guide.PlotReward" => await BuildPlotRewardAsync(ctx, request.Args ?? []),
-            "guide.Setting" => [],
+            "guide.Setting" => await BuildSettingAsync(ctx, request.Args ?? []),
             _ => []
         };
         return ModuleResult.Ok(ret);
+    }
+
+    /// <summary>
+    /// 处理 guide.Setting：把客户端提交的键值写入存档，并回一个带全量设置的 TGuideInfo。
+    /// 客户端 GuideService:_ReceiveUserSetting 按 TGUIDEINFO 解码应答，再用
+    /// GuideData:SetSetting 逐键并入 m_setmap —— 应答不带 Setting，界面读到的就永远是 nil，
+    /// 强化页的三个开关（LOGIC_HERO_INTENSIFY_*）因此恒为关闭。
+    /// SetSetting 是逐键合并而非整表替换，回全量是安全的。
+    /// </summary>
+    private async Task<byte[]> BuildSettingAsync(GameContext ctx, byte[] args)
+    {
+        List<(string Key, string Value)> incoming = ProtocolDecoder.DecodeGuideSettingArg(args);
+        if (incoming.Count == 0)
+            return PlayerDataCodec.Encode(new GuideInfo(Setting: []));
+
+        PlayerAccount account = await ctx.GetAccountAsync();
+        Dictionary<string, string> settings = account.UserSettings is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(account.UserSettings, StringComparer.Ordinal);
+        foreach ((string key, string value) in incoming)
+            settings[key] = value;
+
+        account = account with { UserSettings = settings };
+        await services.SaveAccountAsync(account, ctx.Ct);
+        services.FileLogger.LogInformation("guide.Setting stored {Count} key(s), total={Total}",
+            incoming.Count, settings.Count);
+
+        return PlayerDataCodec.Encode(new GuideInfo(
+            Setting: [.. settings.Select(entry => new GuideSetting(entry.Key, entry.Value))]));
     }
 
     private async Task<byte[]> BuildPlotRewardAsync(GameContext ctx, byte[] args)

--- a/src/BlueOath.Server/Protocols/Modules/HeroModule.cs
+++ b/src/BlueOath.Server/Protocols/Modules/HeroModule.cs
@@ -256,6 +256,49 @@ internal sealed class HeroModule(HeroService hero, GameServices services) : IGam
                     ],
                 };
                 break;
+            case "hero.HeroIntensify":
+                HeroService.IntensifyResult intensify =
+                    await hero.BuildIntensifyRetAsync(request, ctx.ProfileId, ctx.Ct);
+                if (!intensify.Changed || intensify.UpdatedHero is null)
+                {
+                    result = new ModuleResult
+                    {
+                        Ret = intensify.Ret,
+                        Err = 1,
+                        ErrMsg = intensify.Error.Length > 0 ? intensify.Error : "intensify failed",
+                    };
+                    break;
+                }
+                PlayerAccount intensifyAccount = await ctx.GetAccountAsync();
+                uint intensifyNow = (uint)ctx.Now;
+                // 与突破同理：素材舰娘被消耗，HeroData.SetData 只按增量合并，
+                // 必须为每条素材推送 TemplateId=0 的删除标记，再带上更新后的主舰娘。
+                List<HeroGrid> intensifyHeroGrids =
+                [
+                    GameServices.ToHeroGrid(intensify.UpdatedHero),
+                    .. intensify.ConsumedHeroIds.Select(id => new HeroGrid(HeroId: id, TemplateId: 0)),
+                ];
+                // 客户端 _HeroIntensify 只看 err、完全忽略 ret，界面数值全部取自
+                // hero.UpdateHeroBagData 里的 Intensify 字段；缺这条推送就是「动画播了但数值不变」。
+                List<byte[]> intensifyPushes =
+                [
+                    TMessageCodec.EncodeResponse(new TResponse(
+                        Method: "hero.UpdateHeroBagData",
+                        Ret: PlayerDataCodec.Encode(new HeroBag(intensifyHeroGrids, intensifyAccount.Dock.BagSize)),
+                        Time: intensifyNow)),
+                ];
+                // 钻石强化会扣钻，需要刷新货币显示。
+                if (intensify.SpentDiamond > 0)
+                    intensifyPushes.Add(TMessageCodec.EncodeResponse(new TResponse(
+                        Method: "user.UpdateUserInfo",
+                        Ret: GameServices.EncodeGetUserInfo(intensifyAccount),
+                        Time: intensifyNow)));
+                result = new ModuleResult
+                {
+                    Ret = intensify.Ret,
+                    PrePushes = intensifyPushes,
+                };
+                break;
             case "hero.HeroAdvanceMUB":
                 HeroService.AdvanceResult advanceMub =
                     await hero.BuildAdvanceMubRetAsync(request, ctx.ProfileId, ctx.Ct);
@@ -287,7 +330,6 @@ internal sealed class HeroModule(HeroService hero, GameServices services) : IGam
                     ],
                 };
                 break;
-            case "hero.HeroIntensify":
             case "hero.AutoEquip":
             case "hero.AutoUnEquip":
             case "hero.HeroAdvMaxLv":

--- a/src/BlueOath.Server/Protocols/ProtocolDecoder.cs
+++ b/src/BlueOath.Server/Protocols/ProtocolDecoder.cs
@@ -208,6 +208,32 @@ internal static class ProtocolDecoder
         return (heroId, consumedHeros, consumeItems);
     }
 
+    /// <summary>
+    /// 解码 hero.HeroIntensify 参数（TIntensifyHeroArgs）：HeroId(1, uint32),
+    /// ConsumedHeros(2, repeated uint32), SuperIntensify(3, bool)。
+    /// repeated 同时接受未打包（wire 0）与打包（wire 2）两种编码。
+    /// </summary>
+    internal static (uint HeroId, List<uint> ConsumedHeros, bool SuperIntensify) DecodeIntensifyArg(byte[] args)
+    {
+        ProtoReader reader = new(args);
+        uint heroId = 0;
+        List<uint> consumedHeros = [];
+        bool superIntensify = false;
+        while (reader.TryReadField(out int field, out int wire))
+            switch (field)
+            {
+                case 1 when wire == 0: heroId = checked((uint)reader.ReadVarint()); break;
+                case 2 when wire == 0: consumedHeros.Add(checked((uint)reader.ReadVarint())); break;
+                case 2 when wire == 2:
+                    ProtoReader packed = new(reader.ReadBytes());
+                    while (packed.HasRemaining) consumedHeros.Add(checked((uint)packed.ReadVarint()));
+                    break;
+                case 3 when wire == 0: superIntensify = reader.ReadVarint() != 0; break;
+                default: reader.Skip(wire); break;
+            }
+        return (heroId, consumedHeros, superIntensify);
+    }
+
     /// <summary>解码 hero.HeroAdvanceMUB 参数：HeroId(1, uint32),
     /// ConsumeItems(2, repeated TAdvanceMubItemInfo{ItemId=1, ItemNum=2})。</summary>
     internal static (uint HeroId, List<(uint ItemId, int ItemNum)> ConsumeItems) DecodeAdvanceMubArg(byte[] args)

--- a/src/BlueOath.Server/Protocols/ProtocolDecoder.cs
+++ b/src/BlueOath.Server/Protocols/ProtocolDecoder.cs
@@ -234,6 +234,36 @@ internal static class ProtocolDecoder
         return (heroId, consumedHeros, superIntensify);
     }
 
+    /// <summary>
+    /// 解码 guide.Setting 参数（TGuideSettingArg）：param(1, repeated
+    /// TGuideSettingParam{Key=1 string, Value=2 string}）。Key 为空的条目直接丢弃。
+    /// </summary>
+    internal static List<(string Key, string Value)> DecodeGuideSettingArg(byte[] args)
+    {
+        ProtoReader reader = new(args);
+        List<(string, string)> settings = [];
+        while (reader.TryReadField(out int field, out int wire))
+        {
+            if (field == 1 && wire == 2)
+            {
+                ProtoReader item = new(reader.ReadBytes());
+                string key = "", value = "";
+                while (item.TryReadField(out int ifield, out int iwire))
+                {
+                    if (ifield == 1 && iwire == 2) key = item.ReadString();
+                    else if (ifield == 2 && iwire == 2) value = item.ReadString();
+                    else item.Skip(iwire);
+                }
+                if (key.Length > 0) settings.Add((key, value));
+            }
+            else
+            {
+                reader.Skip(wire);
+            }
+        }
+        return settings;
+    }
+
     /// <summary>解码 hero.HeroAdvanceMUB 参数：HeroId(1, uint32),
     /// ConsumeItems(2, repeated TAdvanceMubItemInfo{ItemId=1, ItemNum=2})。</summary>
     internal static (uint HeroId, List<(uint ItemId, int ItemNum)> ConsumeItems) DecodeAdvanceMubArg(byte[] args)

--- a/src/BlueOath.Server/Protocols/Services/GameServices.cs
+++ b/src/BlueOath.Server/Protocols/Services/GameServices.cs
@@ -81,6 +81,7 @@ internal sealed class GameServices
         CopyBattleLoader.Load(configDir);
         MissionChainLoader.Load(configDir);
         ShipBreakLoader.Load(configDir);
+        ShipIntensifyLoader.Load(configDir);
         ShipMainLoader.Load(configDir);
         AssistShipLoader.Load(configDir);
         EquipLoader.Load(configDir, equipmentMods.Equipment);
@@ -690,7 +691,7 @@ internal sealed class GameServices
         new(hero.HeroId, hero.TemplateId, hero.Level, hero.Fashioning, hero.Exp, hero.CreateTime,
             hero.UpdateTime, hero.Affection, hero.MarryTime, hero.CurHp, hero.Mood, hero.MarryType,
             hero.EquipSlots, hero.Name, hero.ChangeNameTime, hero.Lock, hero.Advance, hero.AdvLv, hero.PSkills,
-            hero.RemouldEffects, hero.RemouldLevel);
+            hero.RemouldEffects, hero.RemouldLevel, hero.Intensify);
 
     /// <summary>
     /// 由舰娘 TemplateId（config_ship_main 的 key）推导图鉴 IllustrateId

--- a/src/BlueOath.Server/Protocols/Services/GameServices.cs
+++ b/src/BlueOath.Server/Protocols/Services/GameServices.cs
@@ -197,6 +197,14 @@ internal sealed class GameServices
             new("PlotUtcTime", "0"),
             new("PlotToggleSkipTip", "0"),
         };
+        // 玩家通过 guide.Setting 保存的设置必须一并下发，否则重登后 GuideData:GetSettingByKey
+        // 又变回 nil（强化页三个开关会退回关闭）。同名键以存档为准，覆盖上面的默认值。
+        if (account.UserSettings is { Count: > 0 } stored)
+        {
+            HashSet<string> overridden = [.. stored.Keys];
+            settings.RemoveAll(entry => overridden.Contains(entry.Key));
+            settings.AddRange(stored.Select(entry => new GuideSetting(entry.Key, entry.Value)));
+        }
         var plotList = PlotTriggerLoader.AllPlotIds;
         _fileLogger.LogInformation("guide.GuideInfo push PlotList count={Count}", plotList.Count);
         var guideInfo = new GuideInfo(PlotList: plotList, Setting: settings);

--- a/src/BlueOath.Server/Protocols/Services/HeroService.cs
+++ b/src/BlueOath.Server/Protocols/Services/HeroService.cs
@@ -38,6 +38,14 @@ internal sealed class HeroService(GameServices services)
         bool Changed,
         string Error);
 
+    internal sealed record IntensifyResult(
+        byte[] Ret,
+        Hero? UpdatedHero,
+        IReadOnlyList<uint> ConsumedHeroIds,
+        bool Changed,
+        string Error,
+        int SpentDiamond = 0);
+
     internal sealed record AdvanceResult(
         byte[] Ret,
         Hero? UpdatedHero,
@@ -403,6 +411,140 @@ internal sealed class HeroService(GameServices services)
     }
 
     /// <summary>处理 hero.HeroAdvance：按 config_ship_break 校验并执行突破。</summary>
+    /// <summary>同 enhance_type 素材的强化值加成，config_parameter[110] match_enhance_ratio = 15000（×1e-4）。</summary>
+    private const double IntensifyMatchRatio = 1.5;
+
+    /// <summary>钻石强化（SuperIntensify）的强化值倍率，strengthen_page 的 data.ratio。</summary>
+    private const int SuperIntensifyRatio = 2;
+
+    /// <summary>钻石强化每条素材的钻石花费，config_parameter[31] diamond_num_per_girl = 5。</summary>
+    private const int SuperIntensifyDiamondPerMaterial = 5;
+
+    /// <summary>
+    /// 处理 hero.HeroIntensify（舰船强化）：消耗素材舰娘，按属性累加强化值。
+    /// 数值口径以客户端 Strengthen_Page.GenPropertyData 为准：
+    ///   提供量 = Σ int(provide_power_exp[attr] × (素材与目标同 enhance_type ? 1.5 : 1))
+    ///   钻石强化再 ×2，并按每条素材扣 5 钻石
+    ///   总量   = IntensifyLvl × need + CurExp + 提供量，上限 max_power_prop[attr] × need
+    ///   新等级 = 总量 / need，余量 = 总量 % need
+    /// 客户端 HeroAttr:_GetIntensify 按 AddAttr(AttrType, IntensifyLvl) 加算属性，即 1 级 = 1 点。
+    /// 三张表的键都是随突破变化的 TemplateId（sm_id），必须按舰娘当前模板取。
+    /// </summary>
+    internal async Task<IntensifyResult> BuildIntensifyRetAsync(TRequest request, string profileId, CancellationToken ct)
+    {
+        if (request.Args is null) return new([], null, [], false, "");
+        var (heroId, consumedHeros, superIntensify) = ProtocolDecoder.DecodeIntensifyArg(request.Args);
+
+        using var _ = await services.LockAccountAsync(profileId, ct);
+        PlayerAccount account = await services.GetOrCreateAccountAsync(profileId, ct);
+
+        List<Hero> heroList = account.Dock.Heroes.ToList();
+        if (heroList.Count(h => h.HeroId == heroId) != 1)
+            return new([], null, [], false, "intensify target not found");
+        Hero hero = heroList.First(h => h.HeroId == heroId);
+
+        ConfigShipNeedPowerExp? need = ShipIntensifyLoader.GetNeed(hero.TemplateId);
+        ConfigShipMaxPower? max = ShipIntensifyLoader.GetMax(hero.TemplateId);
+        if (need?.NeedPowerExp is null || max?.MaxPowerProp is null)
+            return new([], null, [], false, "intensify config missing");
+
+        // 素材校验与突破一致：非零、不重复、不含目标本身、实际存在、未上锁、未被占用。
+        // Lvl/Advance/已有强化进度三项对应客户端 Strengthen_PageLogic:ScreenShip 中无条件
+        // 生效的筛选；同型与稀有度两项受界面开关影响，不在服务端强制。
+        if (consumedHeros.Count == 0 || consumedHeros.Any(id => id == 0) ||
+            consumedHeros.Distinct().Count() != consumedHeros.Count || consumedHeros.Contains(heroId))
+            return new([], null, [], false, "invalid intensify materials");
+        HashSet<uint> consumedIdSet = consumedHeros.ToHashSet();
+        List<Hero> materials = heroList.Where(h => consumedIdSet.Contains(h.HeroId)).ToList();
+        if (materials.Count != consumedHeros.Count ||
+            materials.Any(m => m.Lock || m.Level != 1 || m.Advance > 1 ||
+                m.Intensify is { Count: > 0 } || IsHeroInUse(account, m.HeroId)))
+            return new([], null, [], false, "invalid intensify materials");
+
+        int diamondCost = superIntensify ? SuperIntensifyDiamondPerMaterial * materials.Count : 0;
+        if (diamondCost > 0 && account.Character.Diamond < diamondCost)
+            return new([], null, [], false, "not enough diamond");
+
+        long targetType = need.EnhanceType;
+        Dictionary<int, int> maxLevels = ToAttrMap(max.MaxPowerProp);
+        Dictionary<int, AttrIntensify> current = (hero.Intensify ?? [])
+            .GroupBy(entry => entry.AttrType)
+            .ToDictionary(group => group.Key, group => group.First());
+
+        var updated = new List<AttrIntensify>();
+        bool anyGain = false;
+        foreach (List<long> entry in need.NeedPowerExp)
+        {
+            if (entry is not { Count: >= 2 }) continue;
+            int attrType = checked((int)entry[0]);
+            long perLevel = entry[1];
+            AttrIntensify existing = current.TryGetValue(attrType, out AttrIntensify? found)
+                ? found
+                : new AttrIntensify(attrType);
+            // need 为 0 的属性无法换算等级（基础包里确有此类行），保持原样不动。
+            if (perLevel <= 0 || !maxLevels.TryGetValue(attrType, out int maxLevel) || maxLevel <= 0)
+            {
+                updated.Add(existing);
+                continue;
+            }
+
+            long gain = 0;
+            foreach (Hero material in materials)
+            {
+                ConfigShipProvidePowerExp? provide = ShipIntensifyLoader.GetProvide(material.TemplateId);
+                if (provide?.ProvidePowerExp is null) continue;
+                bool sameType = ShipIntensifyLoader.GetNeed(material.TemplateId)?.EnhanceType == targetType;
+                double factor = sameType ? IntensifyMatchRatio : 1.0;
+                foreach (List<long> provided in provide.ProvidePowerExp)
+                    if (provided is { Count: >= 2 } && provided[0] == attrType)
+                        gain = (long)(gain + provided[1] * factor);
+            }
+            if (superIntensify) gain *= SuperIntensifyRatio;
+
+            long total = (long)existing.IntensifyLvl * perLevel + existing.CurExp + gain;
+            long cap = (long)maxLevel * perLevel;
+            if (total > cap) total = cap;
+            var next = new AttrIntensify(attrType, checked((int)(total / perLevel)), checked((int)(total % perLevel)));
+            if (next.IntensifyLvl != existing.IntensifyLvl || next.CurExp != existing.CurExp) anyGain = true;
+            updated.Add(next);
+        }
+
+        // 全属性均已满级时客户端本就用 _CheckNoGains 拦住，这里再兜一层，避免白吃素材。
+        if (!anyGain) return new([], null, [], false, "intensify produced no gain");
+
+        List<uint> consumedIds = materials.Select(m => m.HeroId).ToList();
+        heroList.RemoveAll(h => consumedIdSet.Contains(h.HeroId));
+        Hero updatedHero = hero with { Intensify = updated };
+        int updatedIdx = heroList.FindIndex(h => h.HeroId == heroId);
+        if (updatedIdx < 0) return new([], null, [], false, "intensify target not found");
+        heroList[updatedIdx] = updatedHero;
+
+        // 素材可能携带装备，与突破同样先安全卸下，避免 EquipItem.HeroId 指向已不存在的舰娘。
+        PlayerEquip equip = account.Equip ?? new PlayerEquip([], 2000);
+        List<EquipItem> equipItems = equip.Items
+            .Select(item => consumedIdSet.Contains(item.HeroId) ? item with { HeroId = 0 } : item).ToList();
+
+        account = account with
+        {
+            Dock = account.Dock with { Heroes = heroList },
+            Equip = equip with { Items = equipItems },
+        };
+        if (diamondCost > 0) account = GameServices.AddCurrency(account, 2, -diamondCost);
+
+        await services.SaveAccountAsync(account, ct);
+        return new([], updatedHero, consumedIds, true, "", diamondCost);
+    }
+
+    /// <summary>把 [[attr, value], ...] 形式的配置列摊平成字典，重复项取先出现的一条。</summary>
+    private static Dictionary<int, int> ToAttrMap(List<List<long>> pairs)
+    {
+        var map = new Dictionary<int, int>();
+        foreach (List<long> pair in pairs)
+            if (pair is { Count: >= 2 })
+                map.TryAdd(checked((int)pair[0]), checked((int)pair[1]));
+        return map;
+    }
+
     internal async Task<AdvanceResult> BuildAdvanceRetAsync(TRequest request, string profileId, CancellationToken ct)
     {
         if (request.Args is null) return new([], null, [], false);

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -47,7 +47,8 @@ var tests = new (string Name, Func<Task> Run)[]
     ("fashion shop previews tolerate an unlocked skin without its hero", FashionPreviewModTest),
     ("native draw results only prompt to lock a genuinely new ship", BuildShipNewStateNativePatchTest),
     ("item selection boxes grant the chosen option", SelectTreasureTest),
-    ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest)
+    ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest),
+    ("ship intensify grants attribute levels and consumes materials", ShipIntensifyTest)
 };
 if (args.Contains("--integration", StringComparer.OrdinalIgnoreCase)) tests = [.. tests,
     ("tcp server completes local gameplay flow", TcpIntegrationTest),
@@ -3165,6 +3166,104 @@ static Task TaskCompletionRequiresProgressTest()
     Assert(TaskProtocolCodec.GetEventProgress([definition], partialProgress) == 2,
         "partial task event progress was not preserved");
     return Task.CompletedTask;
+}
+
+// 舰船强化（hero.HeroIntensify）此前是空占位：返回空 Ret、Err=0、不推送，客户端
+// _HeroIntensify 只看 err 就播成功动画，属性却全部取自 THeroGrid.Intensify（字段 7），
+// 于是「强化后数值不变」。数值口径对齐客户端 Strengthen_Page.GenPropertyData。
+static async Task ShipIntensifyTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-ship-intensify-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "ship-intensify";
+    // 10210511：enhance_type=2，need_power_exp = 8:3750 9:5625 10:1125 11:5625 12:2812，
+    //           max_power_prop = 8:24 9:16 10:80 11:16 12:32，provide = 各属性 3000。
+    // 10110111：enhance_type=1（异型），provide = 各属性 1000。
+    const int targetTid = 10210511;
+    const int sameTypeTid = 10210511;
+    const int otherTypeTid = 10110111;
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        PlayerAccount seed = PlayerAccountFactory.CreateDefault(profileId, 1);
+        await repo.SaveAccountAsync(seed with
+        {
+            Character = seed.Character with { SecretaryId = 10 },
+            Dock = new HeroDock(
+            [
+                new Hero(10, targetTid, 5),
+                new Hero(20, sameTypeTid, 1),
+                new Hero(30, otherTypeTid, 1),
+                new Hero(40, sameTypeTid, 1, Lock: true),
+                new Hero(50, sameTypeTid, 9),
+            ]),
+            Fleet = new PlayerFleet([new FleetEntry(1, HeroInfo: [10])]),
+        });
+
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+        var heroService = new HeroService(services);
+
+        static TRequest Intensify(uint heroId, uint[] materials)
+        {
+            var package = new ProtocolPackage().Write(0x08, heroId);
+            foreach (uint material in materials) package.Write(0x10, material);
+            return new TRequest("hero.HeroIntensify", package.ToArray());
+        }
+
+        // 上锁、非 1 级素材必须被拒（对应客户端 ScreenShip / FilterHero 的无条件筛选）。
+        foreach (uint rejected in new uint[] { 40, 50 })
+            Assert(!(await heroService.BuildIntensifyRetAsync(
+                        Intensify(10, [rejected]), profileId, CancellationToken.None)).Changed,
+                $"intensify accepted an ineligible material (hero {rejected})");
+        // 目标自身不能同时作素材。
+        Assert(!(await heroService.BuildIntensifyRetAsync(
+                    Intensify(10, [10]), profileId, CancellationToken.None)).Changed,
+            "intensify accepted the target itself as material");
+
+        HeroService.IntensifyResult result = await heroService.BuildIntensifyRetAsync(
+            Intensify(10, [20, 30]), profileId, CancellationToken.None);
+        Assert(result.Changed && result.UpdatedHero is not null, "intensify did not apply");
+
+        // 同型 3000×1.5=4500，异型 1000×1，合计 5500：
+        //   attr8  5500/3750 -> Lv1 余 1750
+        //   attr10 5500/1125 -> Lv4 余 1000
+        Dictionary<int, AttrIntensify> byAttr =
+            result.UpdatedHero!.Intensify!.ToDictionary(entry => entry.AttrType);
+        Assert(byAttr[8].IntensifyLvl == 1 && byAttr[8].CurExp == 1750,
+            $"attr 8 intensify drifted: Lv{byAttr[8].IntensifyLvl} exp{byAttr[8].CurExp}");
+        Assert(byAttr[10].IntensifyLvl == 4 && byAttr[10].CurExp == 1000,
+            $"attr 10 intensify drifted: Lv{byAttr[10].IntensifyLvl} exp{byAttr[10].CurExp}");
+        // 素材提供了 14/16 的强化值，但目标的 need_power_exp 不含这两项，不应被强化。
+        Assert(!byAttr.ContainsKey(14) && !byAttr.ContainsKey(16),
+            "intensify touched attributes outside the target's need_power_exp");
+        Assert(result.ConsumedHeroIds.Count == 2, "intensify did not consume both materials");
+
+        PlayerAccount after = await repo.LoadAccountAsync(profileId) ?? throw new InvalidDataException("account missing");
+        Assert(after.Dock.Heroes.All(h => h.HeroId != 20 && h.HeroId != 30),
+            "consumed materials remain in the dock");
+
+        // THeroGrid.Intensify 是字段 7（wire 2）。缺这段编码，客户端 HeroAttr:_GetIntensify
+        // 拿到空表，属性加成恒为 0 —— 正是「强化后数值不变」的直接原因。
+        // attr8 子消息：08 08 (AttrType=8) 10 01 (Lv=1) 18 D6 0D (CurExp=1750)，共 7 字节。
+        byte[] encoded = PlayerDataCodec.Encode(GameServices.ToHeroGrid(result.UpdatedHero!));
+        Assert(ContainsSequence(encoded, [0x3A, 0x07, 0x08, 0x08, 0x10, 0x01, 0x18, 0xD6, 0x0D]),
+            "hero grid did not encode Intensify as field 7");
+
+        // 满级后再强化不应白吃素材。
+        HeroService.IntensifyResult noGain = await heroService.BuildIntensifyRetAsync(
+            Intensify(10, [20]), profileId, CancellationToken.None);
+        Assert(!noGain.Changed, "intensify consumed an already-removed material");
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
 }
 
 static string FindClientConfigDir()

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -48,7 +48,8 @@ var tests = new (string Name, Func<Task> Run)[]
     ("native draw results only prompt to lock a genuinely new ship", BuildShipNewStateNativePatchTest),
     ("item selection boxes grant the chosen option", SelectTreasureTest),
     ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest),
-    ("ship intensify grants attribute levels and consumes materials", ShipIntensifyTest)
+    ("ship intensify grants attribute levels and consumes materials", ShipIntensifyTest),
+    ("guide user settings persist and ship on the login push", GuideUserSettingTest)
 };
 if (args.Contains("--integration", StringComparer.OrdinalIgnoreCase)) tests = [.. tests,
     ("tcp server completes local gameplay flow", TcpIntegrationTest),
@@ -3259,6 +3260,91 @@ static async Task ShipIntensifyTest()
         HeroService.IntensifyResult noGain = await heroService.BuildIntensifyRetAsync(
             Intensify(10, [20]), profileId, CancellationToken.None);
         Assert(!noGain.Changed, "intensify consumed an already-removed material");
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
+}
+
+// 强化页的三个开关（LOGIC_HERO_INTENSIFY_TypeMatchCancel / _RHeroSelect / _MORESELECT）
+// 都通过 guide.Setting 存取，服务端此前是 "guide.Setting" => [] 直接丢弃，客户端
+// GuideData:GetSettingByKey 永远读到 nil，开关恒为关闭：筛选只认 N 品质、选择槽固定 6 格，
+// 「一斉追加」于是常年提示「条件を満たした戦姫はいません」。
+// 客户端 GuideService:_ReceiveUserSetting 按 TGuideInfo 解应答，所以应答必须带 Setting；
+// 登录的 guide.GuideInfo 也要带上，否则重登即丢。
+static async Task GuideUserSettingTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-guide-setting-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "guide-setting";
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        await repo.SaveAccountAsync(PlayerAccountFactory.CreateDefault(profileId, 1));
+
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+        var guide = new GuideModule(services);
+        var ctx = new GameContext
+        {
+            ProfileId = profileId,
+            Now = 1,
+            Ct = CancellationToken.None,
+            Services = services,
+        };
+
+        static byte[] SettingArgs(params (string Key, string Value)[] entries)
+        {
+            var package = new ProtocolPackage();
+            foreach ((string key, string value) in entries)
+            {
+                var body = new ProtocolPackage()
+                    .Write(0x0A, key)
+                    .Write(0x12, value);
+                package.Write(0x0A, body.ToArray());
+            }
+            return package.ToArray();
+        }
+
+        ModuleResult saved = await guide.HandleAsync(ctx, new TRequest("guide.Setting",
+            SettingArgs(("LOGIC_HERO_INTENSIFY_RHeroSelect", "true"),
+                        ("LOGIC_HERO_INTENSIFY_MORESELECT", "true"))));
+        // 应答必须是带 Setting 的 TGuideInfo：字段 3 的子消息里 Key/Value 都是 string。
+        Assert(saved.Ret is { Length: > 0 }, "guide.Setting returned an empty payload");
+        Assert(ContainsSequence(saved.Ret!,
+                   System.Text.Encoding.UTF8.GetBytes("LOGIC_HERO_INTENSIFY_RHeroSelect")) &&
+               ContainsSequence(saved.Ret!,
+                   System.Text.Encoding.UTF8.GetBytes("LOGIC_HERO_INTENSIFY_MORESELECT")),
+            "guide.Setting response did not echo the stored settings");
+
+        PlayerAccount stored = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("account missing");
+        Assert(stored.UserSettings?["LOGIC_HERO_INTENSIFY_RHeroSelect"] == "true" &&
+               stored.UserSettings?["LOGIC_HERO_INTENSIFY_MORESELECT"] == "true",
+            "guide.Setting did not persist the submitted keys");
+
+        // 再提交一次：同键覆盖、异键并入，不能整表替换。
+        await guide.HandleAsync(ctx, new TRequest("guide.Setting",
+            SettingArgs(("LOGIC_HERO_INTENSIFY_RHeroSelect", "false"),
+                        ("LOGIC_HERO_INTENSIFY_TypeMatchCancel", "true"))));
+        stored = await repo.LoadAccountAsync(profileId) ?? throw new InvalidDataException("account missing");
+        Assert(stored.UserSettings?.Count == 3 &&
+               stored.UserSettings["LOGIC_HERO_INTENSIFY_RHeroSelect"] == "false" &&
+               stored.UserSettings["LOGIC_HERO_INTENSIFY_MORESELECT"] == "true" &&
+               stored.UserSettings["LOGIC_HERO_INTENSIFY_TypeMatchCancel"] == "true",
+            "guide.Setting replaced the map instead of merging keys");
+
+        // 登录推送必须带上存档里的设置，否则重登即丢。
+        byte[] push = services.BuildGuideInfoPush(1, stored);
+        Assert(ContainsSequence(push,
+                   System.Text.Encoding.UTF8.GetBytes("LOGIC_HERO_INTENSIFY_TypeMatchCancel")),
+            "guide.GuideInfo login push omitted the persisted user settings");
     }
     finally
     {


### PR DESCRIPTION
修复 #73。两处根因不同但同属强化系统：

| 提交 | 内容 |
|---|---|
| 1 | 实现舰船强化 `hero.HeroIntensify` |
| 2 | 实现 `guide.Setting`，持久化全局用户设置 |

> **依赖 #74**：当前 `master` 的 `src/BlueOath.Tests` 编译不过（`DailyCopyGameplayTest` 里 ref struct 出现在 async 方法体内，CS8652 ×3）。本 PR 只含功能改动、不带那个修复，所以在 #74 合入之前，这里的测试项目同样构建不了。两者合入后可全绿。

### 一、舰船强化

数据结构是反编译客户端 `hero_pb.lua` 取得的，`docs/protocol-catalog/jp-1.4.0.proto` 未收录：

```
THeroGrid.Intensify = 字段 7, repeated TAttrIntensify
TAttrIntensify     { AttrType:1, IntensifyLvl:2, CurExp:3 }
TIntensifyHeroArgs { HeroId:1, ConsumedHeros:2 repeated, SuperIntensify:3 bool }
```

`HeroGrid` 的编码器用的是显式字段号，字段 7 只是从来没写过，加上去是纯增量。

数值口径对齐客户端 `Strengthen_Page.GenPropertyData`：

```
提供量 = Σ int(provide_power_exp[attr] × (素材与目标同 enhance_type ? 1.5 : 1))
         同型系数 = config_parameter[110] match_enhance_ratio 15000 × 1e-4
钻石强化（SuperIntensify）再 ×2，并按 config_parameter[31] 每条素材扣 5 钻石
总量   = IntensifyLvl × need + CurExp + 提供量，上限 max_power_prop[attr] × need
新等级 = 总量 / need，余量 = 总量 % need
1 级强化 = 1 点属性（客户端 AddAttr 直接加算 IntensifyLvl）
```

三张表的键都是随突破变化的 `TemplateId`（`sm_id`），按战姬当前模板取。

改动：

- **`PlayerDataCodec`**：新增 `AttrIntensify`；`HeroGrid` 增加 `Intensify`；编码字段 7，三个子字段无条件写出（`strengthen_page` 里 `purelv × needExp` 等算术取到 nil 会崩）。
- **`PlayerEntities`**：`Hero` 增加 `Intensify` 并持久化。
- **`ConfigLoaders`**：新增 `ShipIntensifyLoader` 一次加载三张表；`GameServices` 装载。
- **`ProtocolDecoder`**：新增 `DecodeIntensifyArg`，repeated 同时接受打包与未打包编码。
- **`HeroService.BuildIntensifyRetAsync`**：素材校验与突破一致（非零、不重复、不含目标、存在、未上锁、未被占用），另加 `Lvl == 1` / `Advance <= 1` / 无强化进度三项 —— 对应客户端 `ScreenShip` 中**无条件生效**的筛选；同型与稀有度受界面开关影响，不在服务端强制。`need` 为 0 的属性跳过（基础包确有此类行），全属性无增益时拒绝以免白吃素材。
- **`HeroModule`**：从占位组摘出，推 `hero.UpdateHeroBagData`（含素材的 `TemplateId = 0` 删除标记）。
- **虽然包含钻石强化的逻辑，但实际测试中没有发现该功能，不过对强化功能的实现和其他玩法没有影响。**

### 二、`guide.Setting`

- `PlayerAccount` 增加 `UserSettings` 字典并持久化。
- `ProtocolDecoder` 新增 `DecodeGuideSettingArg`，`Key` 为空的条目丢弃。
- `GuideModule` 实现 `guide.Setting`：逐键合并写入存档，应答回带**全量** `Setting` 的 `TGuideInfo`（`SetSetting` 是逐键并入而非整表替换，回全量安全）。
- `BuildGuideInfoPush` 把存档里的设置并进登录推送，同名键以存档为准，否则重登即丢。

`strengthen_page.lua:63` 注册了 `GuideSettingReceive → _OnSetOk`，应答回来界面会立刻刷新，不需要重开页面。

### 验证

全套 **36 个用例通过，0 警告 0 错误**。

新增两个用例：

- `ship intensify grants attribute levels and consumes materials` —— 用真实配置钉数值：目标 `10210511`（`enhance_type = 2`），同型素材 3000 × 1.5 + 异型素材 1000 = 5500 → `attr8`（need 3750）Lv1 余 1750、`attr10`（need 1125）Lv4 余 1000；素材提供但不在目标 `need_power_exp` 内的 `attr14/16` 不被强化；素材移出船坞；`HeroGrid` 确实编码出字段 7；上锁 / 非 1 级 / 目标自身作素材均被拒。
- `guide user settings persist and ship on the login push` —— 应答带回提交的键；写入存档；二次提交同键覆盖、异键并入且不整表替换；登录推送 `guide.GuideInfo` 带上存档中的设置。

游戏内也实测过：强化数值正常结算。

Fixes #73
