### PR TITLE
feat: 补齐装备类自选箱（config_item_selected.type == 2）

### DIFF
--- a/src/BlueOath.Server/Protocols/Services/ShopService.cs
+++ b/src/BlueOath.Server/Protocols/Services/ShopService.cs
@@ -97,7 +97,9 @@ internal sealed class ShopService(GameServices services)
         return new(ret, true, "", remaining == 0 ? arg.TreasureId : 0);
     }
 
-    /// <summary>config_item_selected.type：3 = 道具箱（本方法只处理这一类）。</summary>
+    /// <summary>config_item_selected.type：2 = 装备箱，3 = 道具箱（本方法处理这两类）。</summary>
+    private const int SelectedTypeEquip = 2;
+
     private const int SelectedTypeItem = 3;
 
     /// <summary>
@@ -107,8 +109,9 @@ internal sealed class ShopService(GameServices services)
     /// config_item_selected.item_id 的下标；item_id 为空而 drop_id &gt; 0 时是随机选择箱，
     /// 客户端固定传 position=0，由服务端从掉落池抽取。
     ///
-    /// 只处理 type == 3 的道具箱：舰船箱（type 1）与装备箱（type 2）另有实现，此处返回
-    /// Changed=false 且不带错误，交由调用方保持原有的空响应，行为与改动前一致。
+    /// 处理 type == 3 的道具箱与 type == 2 的装备箱。装备箱共 75 个（46 个带 item_id、
+    /// 29 个是 drop_id 随机箱），其 558 条选项的 GoodsType 全部是 2，不存在混合类型。
+    /// 舰船箱（type 1）仍未实现，返回 Changed=false 且不带错误，交由调用方保持空响应。
     /// </summary>
     internal async Task<TreasureOpenResult> BuildOpenSelectTreasureRetAsync(
         TRequest request, string profileId, CancellationToken ct)
@@ -121,8 +124,8 @@ internal sealed class ShopService(GameServices services)
             return new([], false, "select treasure id or count is invalid");
         if (!services.ItemSelected.TryGetValue(arg.TreasureId, out ConfigItemSelected? config))
             return new([], false, "select treasure configuration was not found");
-        // 非道具箱不在本次实现范围内，保持原有空响应。
-        if (config.Type != SelectedTypeItem) return new([], false, "");
+        // 舰船箱尚未实现，保持原有空响应。
+        if (config.Type is not (SelectedTypeItem or SelectedTypeEquip)) return new([], false, "");
 
         List<List<long>> options = config.ItemId ?? [];
         var pending = new List<PendingReward>();
@@ -137,8 +140,7 @@ internal sealed class ShopService(GameServices services)
             int configId = checked((int)option[1]);
             int num = checked((int)option[2]);
             if (num <= 0) return new([], false, "select treasure option has a non-positive count");
-            // 舰船/装备的发放路径本次不动，避免与既有实现产生分歧。
-            if (type is GameServices.GoodsTypeShip or GameServices.GoodsTypeEquip)
+            if (type == GameServices.GoodsTypeShip)
                 return new([], false, "select treasure option type is not supported yet");
             for (var i = 0; i < openNum; i++) pending.Add(new PendingReward(type, configId, num));
         }
@@ -150,7 +152,7 @@ internal sealed class ShopService(GameServices services)
                 if (!TryDrawPool(checked((int)config.DropId), pending, [], 0))
                     return new([], false, "select treasure drop pool is invalid");
             }
-            if (pending.Any(x => x.Type is GameServices.GoodsTypeShip or GameServices.GoodsTypeEquip))
+            if (pending.Any(x => x.Type == GameServices.GoodsTypeShip))
                 return new([], false, "select treasure reward type is not supported yet");
         }
 
@@ -161,6 +163,18 @@ internal sealed class ShopService(GameServices services)
         if (bagIndex < 0 || bag.Items[bagIndex].Num < openNum)
             return new([], false, "select treasure count is insufficient");
 
+        // 装备仓库容量与模板校验必须在扣除箱子之前完成，失败时不能消耗道具。
+        int newEquipCount = pending.Where(x => x.Type == GameServices.GoodsTypeEquip).Sum(x => x.Num);
+        if (newEquipCount > 0)
+        {
+            PlayerEquip equipBag = account.Equip ?? new PlayerEquip([], EquipBagSize: 2000);
+            if (equipBag.Items.Count + newEquipCount > equipBag.EquipBagSize)
+                return new([], false, "equipment bag is full");
+            if (pending.Any(x => x.Type == GameServices.GoodsTypeEquip &&
+                                 services.GetEquipConfig(x.ConfigId) is null))
+                return new([], false, "select treasure contains an unknown equipment template");
+        }
+
         var bagItems = bag.Items.ToList();
         int remaining = bagItems[bagIndex].Num - openNum;
         if (remaining == 0) bagItems.RemoveAt(bagIndex);
@@ -170,6 +184,21 @@ internal sealed class ShopService(GameServices services)
         var rewards = new List<CommonReward>();
         foreach (PendingReward reward in pending)
         {
+            if (reward.Type == GameServices.GoodsTypeEquip)
+            {
+                // 装备是逐件生成实例的：每件分配一个 EquipsId，奖励里必须带上它，
+                // 否则客户端 ShowCommonReward 拿不到实例、装备也进不了仓库。
+                for (var i = 0; i < reward.Num; i++)
+                {
+                    uint equipId = services.NextEquipId();
+                    PlayerEquip equipBag = account.Equip ?? new PlayerEquip([], EquipBagSize: 2000);
+                    var equipItems = equipBag.Items.ToList();
+                    equipItems.Add(new EquipItem(equipId, reward.ConfigId));
+                    account = account with { Equip = equipBag with { Items = equipItems } };
+                    rewards.Add(new CommonReward(reward.Type, reward.ConfigId, 1, checked((int)equipId)));
+                }
+                continue;
+            }
             if (reward.Type == GameServices.GoodsTypeCurrency)
                 account = GameServices.AddCurrency(account, reward.ConfigId, reward.Num);
             else if (reward.Type == GameServices.GoodsTypeFashion)

--- a/src/BlueOath.Tests/Program.cs
+++ b/src/BlueOath.Tests/Program.cs
@@ -47,7 +47,8 @@ var tests = new (string Name, Func<Task> Run)[]
     ("fashion shop previews tolerate an unlocked skin without its hero", FashionPreviewModTest),
     ("native draw results only prompt to lock a genuinely new ship", BuildShipNewStateNativePatchTest),
     ("item selection boxes grant the chosen option", SelectTreasureTest),
-    ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest)
+    ("tls material loads in OpenSSL proxy runtime", TlsCaptureIntegrationTest),
+    ("equipment selection boxes grant an equipment instance", EquipSelectTreasureTest)
 };
 if (args.Contains("--integration", StringComparer.OrdinalIgnoreCase)) tests = [.. tests,
     ("tcp server completes local gameplay flow", TcpIntegrationTest),
@@ -3165,6 +3166,90 @@ static Task TaskCompletionRequiresProgressTest()
     Assert(TaskProtocolCodec.GetEventProgress([definition], partialProgress) == 2,
         "partial task event progress was not preserved");
     return Task.CompletedTask;
+}
+
+// 装备自选箱（config_item_selected.type == 2）此前和舰船箱一起被挡在实现之外：
+// BuildOpenSelectTreasureRetAsync 对非 type==3 直接返回 Changed=false 且不带错误，
+// ShopModule 据此保持 ModuleResult.Empty，客户端 err==0 解出空 treasuresInfo，
+// 表现为「选了装备点收取却什么都没拿到」，箱子也不消耗。
+// 装备与道具的区别在于它是逐件生成实例的：每件要分配 EquipsId 并随奖励下发。
+static async Task EquipSelectTreasureTest()
+{
+    string root = FindRepositoryRoot();
+    string dataRoot = Path.Combine(Path.GetTempPath(), "blueoath-equip-box-" + Guid.NewGuid().ToString("N"));
+    const string profileId = "equip-box";
+    // 80190：type=2，16 个选项，全部 [2, equipTemplateId, 1]；第 1 项 30444、第 2 项 30154。
+    const int equipBoxId = 80190;
+    const int firstEquipTid = 30444;
+    const int secondEquipTid = 30154;
+    const int optionCount = 16;
+    const int itemBoxId = 80134;   // type=3 道具箱，确认改动没有影响原有路径
+    try
+    {
+        var repo = new SqliteGameRepository(dataRoot);
+        await repo.SaveAccountAsync(PlayerAccountFactory.CreateDefault(profileId, 1) with
+        {
+            Bag = new PlayerBag([new BagItem(equipBoxId, 3), new BagItem(itemBoxId, 1)], 200),
+            Equip = new PlayerEquip([], 2000),
+        });
+
+        ServerOptions options = ServerOptions.Parse(
+            ["--data=" + dataRoot,
+             "--client-path=" + Path.Combine(root, "blueoath", "blueoath"),
+             "--profile-id=" + profileId]);
+        using Microsoft.Extensions.Logging.ILoggerFactory loggerFactory =
+            Microsoft.Extensions.Logging.LoggerFactory.Create(_ => { });
+        var services = new GameServices(repo, options, loggerFactory);
+        var shop = new ShopService(services);
+
+        static TRequest Open(int treasureId, int position, int num = 1) =>
+            new("bag.GetSelectTreasureInfo", new ProtocolPackage()
+                .Write(0x08, (ulong)treasureId).Write(0x10, (ulong)position).Write(0x18, (ulong)num).ToArray());
+
+        // 第 1 项：拿到 30444 而不是 30154（序号是 1 基）。
+        ShopService.TreasureOpenResult first = await shop.BuildOpenSelectTreasureRetAsync(
+            Open(equipBoxId, 1), profileId, CancellationToken.None);
+        Assert(first.Changed, $"equipment box was not opened: {first.Error}");
+        PlayerAccount after = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("account missing");
+        Assert(after.Equip!.Items.Count == 1 && after.Equip.Items[0].TemplateId == firstEquipTid,
+            "equipment box did not grant the selected option as an equipment instance");
+        Assert(after.Equip.Items[0].EquipId != 0,
+            "granted equipment has no instance id");
+        Assert(after.Bag!.Items.All(x => x.TemplateId != secondEquipTid) &&
+               after.Bag.Items.All(x => x.TemplateId != firstEquipTid),
+            "equipment reward polluted the item bag");
+        Assert(after.Bag.Items.Single(x => x.TemplateId == equipBoxId).Num == 2,
+            "equipment box was not consumed exactly once");
+
+        // 末项可选；两侧越界被拒且不扣箱子。
+        Assert((await shop.BuildOpenSelectTreasureRetAsync(
+                    Open(equipBoxId, optionCount), profileId, CancellationToken.None)).Changed,
+            "equipment box rejected its last option");
+        foreach (int bad in new[] { 0, optionCount + 1 })
+        {
+            ShopService.TreasureOpenResult rejected = await shop.BuildOpenSelectTreasureRetAsync(
+                Open(equipBoxId, bad), profileId, CancellationToken.None);
+            Assert(!rejected.Changed && rejected.Error.Length > 0,
+                $"equipment box accepted an out-of-range position {bad}");
+        }
+        PlayerAccount afterBad = await repo.LoadAccountAsync(profileId)
+            ?? throw new InvalidDataException("account missing");
+        Assert(afterBad.Bag!.Items.Single(x => x.TemplateId == equipBoxId).Num == 1,
+            "an out-of-range position still consumed the equipment box");
+        Assert(afterBad.Equip!.Items.Count == 2 &&
+               afterBad.Equip.Items.Select(x => x.EquipId).Distinct().Count() == 2,
+            "equipment instances collided or were not persisted");
+
+        // 道具箱路径不受影响。
+        Assert((await shop.BuildOpenSelectTreasureRetAsync(
+                    Open(itemBoxId, 1), profileId, CancellationToken.None)).Changed,
+            "item selection box regressed");
+    }
+    finally
+    {
+        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, true);
+    }
 }
 
 static string FindClientConfigDir()


### PR DESCRIPTION
修复 #71。

## 根因

`bag.GetSelectTreasureInfo` 在 #68 里只实现了 `type == 3` 的道具箱，对其余类型返回 `Changed = false` 且 `Error` 为空，`ShopModule` 据此保持 `ModuleResult.Empty`。客户端因 `err == 0` 照常解码，拿到空的 `treasuresInfo`，`ShowCommonReward` 无显示且log无报错。

需要更正一处我在 #68 里写下的说明：当时把装备箱排除在实现之外，依据是随机装备箱功能正常，但当时自选装备箱没有测试具体实现。代码注释里那句一并改掉了。

## 数据

`config_item_selected` 中 `type == 2` 共 **75 个**：46 个带 `item_id`、29 个是 `drop_id` 随机箱。带 `item_id` 的 **558 条选项 GoodsType 全部是 2**（装备），不存在混合类型。

## 改动

- 类型门槛放开到 `type 2` 与 `type 3`。
- 指定选项与随机池两条路径都不再拒绝 `GoodsTypeEquip`，仅继续拒绝 `GoodsTypeShip`。
- **扣除箱子之前**补上装备仓库容量与模板校验，与 `BuildOpenNormalTreasureRetAsync` 用同一套；校验失败不消耗道具。
- 发放时逐件生成实例：每件分配 `NextEquipId()`、写入 `PlayerEquip`，并把 `EquipsId` 随 `CommonReward` 下发，客户端 `ShowCommonReward` 需要实例 id，缺了装备进不了仓库。这是装备与道具发放路径的关键区别。

## 验证

新增用例以 `80190`（`type = 2`，16 个选项，首项 `30444`、次项 `30154`）为样本：

- `position = 1` 拿到 `30444` 而非 `30154`（序号是 1 基）
- 装备进装备仓库、不污染道具背包；实例 id 非零且互不重复
- 末项（`position = 16`）可选；`position = 0` 与 `17` 两侧越界被拒**且不扣箱子**
- 同时复跑道具箱（`type = 3`）路径，确认 #68 的实现无回归

在合并树上全套 **37 个用例通过，0 警告 0 错误**。

`type == 2` 里那 29 个随机装备箱（`item_id` 为空、走 `drop_id`，客户端固定传 `position = 0`）这次一并放行，但没有单独用例覆盖。

## 依赖 #74

当前 `master` 的 `src/BlueOath.Tests` 编译不过（`DailyCopyGameplayTest` 里 ref struct 出现在 async 方法体内，CS8652 ×3）。本 PR 只含功能改动、不带那个修复，所以在 #74 合入之前，这里的测试项目同样构建不了——上面的 37 个用例是在带 #74 的合并树上跑的，功能代码与本分支逐字节相同。

Fixes #71
